### PR TITLE
Fix long description content type

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,0 @@
-Erez Freiberger <erez@epsagon.com>
-ranrib <ran@epsagon.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,0 @@
-CHANGES
-=======
-
-* Use PBR for versioning and packaging
-* adding tox for multi environment testing
-* Updating README
-* Updating description
-* Initial commit

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,4 +1,5 @@
 git config --global user.name "semantic-release (via TravisCI)"
 git config --global user.email "semantic-release@travis"
+pip install --upgrade wheel setuptools twine pkginfo
 pip install python-semantic-release
 semantic-release publish


### PR DESCRIPTION
I think that travis might be using old versions of one of the release packages that doesn't send `long_description_content_type` so this updates those packages.

also removing authors and changelog files that are not maintained automatically anymore.