### PR TITLE
Add debug flag and capture transmission errors

### DIFF
--- a/epsagon/common.py
+++ b/epsagon/common.py
@@ -14,4 +14,3 @@ class EpsagonWarning(Warning):
     """
     An Epsagon warning.
     """
-    pass

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -243,12 +243,12 @@ class Trace(object):
             if self.debug:
                 print("Sending traces:")
                 pprint.pprint(self.to_dict())
-        except requests.exceptions.ReadTimeout as e:
+        except requests.exceptions.ReadTimeout as exception:
             if self.debug:
-                print("Failed to send traces (timeout): ", e)
-        except Exception as e:
+                print("Failed to send traces (timeout): ", exception)
+        except Exception as exception:
             if self.debug:
-                print("Failed to send traces: ", e)
+                print("Failed to send traces: ", exception)
 
 
 # pylint: disable=C0103

--- a/epsagon/utils.py
+++ b/epsagon/utils.py
@@ -65,7 +65,8 @@ def init(token,
          app_name='default',
          collector_url=None,
          metadata_only=True,
-         use_ssl=False
+         use_ssl=False,
+         debug=False
          ):
     """
     Initializes trace with user's data.
@@ -74,7 +75,8 @@ def init(token,
     :param app_name: application name
     :param collector_url: the url of the collector.
     :param metadata_only: whether to send only the metadata, or also the data.
-    :param use_ssl:L whether to use SSL or not.
+    :param use_ssl: whether to use SSL or not.
+    :param debug: debug mode flag
     :return: None
     """
     if not collector_url:
@@ -84,5 +86,6 @@ def init(token,
         app_name=app_name,
         collector_url=collector_url,
         metadata_only=metadata_only,
-        use_ssl=use_ssl
+        use_ssl=use_ssl,
+        debug=debug
     )

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -483,7 +483,8 @@ def test_init_sanity(wrapped_init):
         app_name='app-name',
         collector_url='collector',
         metadata_only=False,
-        use_ssl=False
+        use_ssl=False,
+        debug=False
     )
 
 
@@ -494,14 +495,15 @@ def test_init_empty_app_name(wrapped_init):
         app_name='',
         collector_url='collector',
         metadata_only=False,
-        use_ssl=True
+        use_ssl=True,
     )
     wrapped_init.assert_called_with(
         token='token',
         app_name='',
         collector_url='collector',
         metadata_only=False,
-        use_ssl=True
+        use_ssl=True,
+        debug=False
     )
 
 
@@ -514,6 +516,7 @@ def test_init_empty_collector_url(wrapped_init):
         collector_url=get_tc_url(False),
         metadata_only=False,
         use_ssl=False,
+        debug=False
     )
 
 
@@ -528,7 +531,8 @@ def test_init_no_ssl_no_url(wrapped_init):
         collector_url=TRACE_COLLECTOR_URL.format(
             region=DEFAULT_REGION,
             protocol="http://"
-        )
+        ),
+        debug=False
     )
 
 
@@ -548,7 +552,8 @@ def test_init_ssl_no_url(wrapped_init):
         collector_url=TRACE_COLLECTOR_URL.format(
             region=DEFAULT_REGION,
             protocol="https://"
-        )
+        ),
+        debug=False
     )
 
 
@@ -566,7 +571,8 @@ def test_init_ssl_with_url(wrapped_init):
         app_name='app-name',
         metadata_only=False,
         use_ssl=True,
-        collector_url="http://abc.com"
+        collector_url="http://abc.com",
+        debug=False
     )
 
 
@@ -584,5 +590,6 @@ def test_init_no_ssl_with_url(wrapped_init):
         app_name='app-name',
         metadata_only=False,
         use_ssl=False,
-        collector_url="http://abc.com"
+        collector_url="http://abc.com",
+        debug=False
     )

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -108,25 +108,31 @@ def test_initialize():
     collector_url = 'collector_url'
     metadata_only = False
     use_ssl = True
-    tracer.initialize(app_name, token, collector_url, metadata_only, use_ssl)
+    debug = True
+    tracer.initialize(
+        app_name, token, collector_url, metadata_only, use_ssl, debug
+    )
     assert tracer.app_name == app_name
     assert tracer.token == token
     assert tracer.collector_url == collector_url
     assert tracer.use_ssl == use_ssl
+    assert tracer.debug == debug
 
-    tracer.initialize(app_name, '', '', False, False)
+    tracer.initialize(app_name, '', '', False, False, False)
     assert tracer.app_name == app_name
     assert tracer.token == ''
     assert tracer.collector_url == ''
     assert tracer.metadata_only == False
     assert tracer.use_ssl == False
+    assert tracer.debug == False
 
-    tracer.initialize('', '', '', True, True)
+    tracer.initialize('', '', '', True, True, False)
     assert tracer.app_name == ''
     assert tracer.token == ''
     assert tracer.collector_url == ''
     assert tracer.metadata_only == True
     assert tracer.use_ssl == True
+    assert tracer.debug == False
 
 
 def test_load_from_dict():


### PR DESCRIPTION
This PR includes:

1. Adding debug flag to epsagon init so it will be easier to turn on / off debug mode
2. Printing errors that occur during the transmission of traces