### PR TITLE
feat(trace.py): adding set_error to set runner exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ def handler(event, context):
   pass
 ```
 
+## Set Error
+
+Set a custom error, maybe without even failing the function:
+```python
+@epsagon.lambda_wrapper
+def handler(event, context):
+  if 'my_param' not in event:
+      epsagon.error(ValueError('event missing my_param'))
+  pass
+```
+
 ## Copyright
 
 Provided under the MIT license. See LICENSE for details.

--- a/epsagon/__init__.py
+++ b/epsagon/__init__.py
@@ -49,6 +49,7 @@ else:
 
 # pylint: disable=C0103
 label = tracer.add_label
+error = tracer.set_error
 
 __all__ = ['lambda_wrapper', 'azure_wrapper', 'python_wrapper', 'init',
            'step_lambda_wrapper', 'flask_wrapper', 'wrapper', 'gcp_wrapper']

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -264,6 +264,16 @@ class Trace(object):
             return
         self.custom_labels[key] = value
 
+    def set_error(self, exception: Exception, traceback_data=None):
+        """
+        Sets the error value of the runner
+        :param exception: Exception object to set.
+        :param traceback_data: traceback string
+        """
+        if not traceback_data:
+            traceback_data = ''.join(traceback.extract_stack().format())
+        self.runner.set_exception(exception, traceback_data)
+
     def update_runner_with_labels(self):
         """
         Adds the custom labels to the runner of the trace


### PR DESCRIPTION
```python
epsagon.error(ValueError('Wrong something'), ''.join(traceback.extract_stack().format()) )
```