### PR TITLE
fix(http_filters): filter amazonaws requests

### DIFF
--- a/epsagon/wrappers/http_filters.py
+++ b/epsagon/wrappers/http_filters.py
@@ -27,10 +27,10 @@ IGNORED_FILE_TYPES = [
 BLACKLIST_URLS = {
     str.endswith: [
         'epsagon.com',
+        '.amazonaws.com',
     ],
     str.__contains__: [
         'accounts.google.com',
-        '.amazonaws.com',
     ],
 }
 

--- a/epsagon/wrappers/http_filters.py
+++ b/epsagon/wrappers/http_filters.py
@@ -30,6 +30,7 @@ BLACKLIST_URLS = {
     ],
     str.__contains__: [
         'accounts.google.com',
+        '.amazonaws.com',
     ],
 }
 


### PR DESCRIPTION
Since releasing https://github.com/epsagon/epsagon-python/pull/70, we capture all botocore requests twice (once regular, and once as an HTTP req). this PR fixes it.