### PR TITLE
fix(urllib3.py): fix duplication and data extraction error

### DIFF
--- a/epsagon/events/urllib3.py
+++ b/epsagon/events/urllib3.py
@@ -96,7 +96,7 @@ class Urllib3Event(BaseEvent):
             add_data_if_needed(
                 self.resource['metadata'],
                 'response_body',
-                str(response.data)
+                str(getattr(response, '_fp').fp.peek())
             )
         except ValueError:
             pass

--- a/epsagon/modules/urllib3.py
+++ b/epsagon/modules/urllib3.py
@@ -32,11 +32,6 @@ def patch():
             'HTTPConnectionPool.urlopen',
             _wrapper
         )
-        wrapt.wrap_function_wrapper(
-            'urllib3',
-            'HTTPSConnectionPool.urlopen',
-            _wrapper
-        )
     except Exception:  # pylint: disable=broad-except
         # Can happen in different Python versions.
         pass


### PR DESCRIPTION
There was a duplication in wrapping.
In addition, response.data was reading the fp data, so it left the user without data.