### PR TITLE
fix(flask.py): ignore flask url_rule and not path

### DIFF
--- a/epsagon/wrappers/flask.py
+++ b/epsagon/wrappers/flask.py
@@ -150,7 +150,7 @@ class FlaskWrapper(object):
             self.exception_handler[sys.version_info.major](exception)
 
         # Ignoring endpoint, only if no error happened.
-        if not exception and request.path in self.ignored_endpoints:
+        if not exception and request.url_rule.rule in self.ignored_endpoints:
             return
 
         trace = epsagon.trace.trace_factory.get_or_create_trace()


### PR DESCRIPTION
Fixing cases for endpoint like `/something/<id>`.
request.path = `/something/1`, where request.url_rule.rule = `/something/<id>`.