### PR TITLE
fix(chalice.py): add Chalice specific wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ app = Chalice(app_name="hello-world")
 def index():
     return {"hello": "world"}
 
-app = epsagon.lambda_wrapper(app)
+app = epsagon.chalice_wrapper(app)
 ```
 
 ### Zappa

--- a/epsagon/__init__.py
+++ b/epsagon/__init__.py
@@ -26,6 +26,7 @@ if os.getenv('DISABLE_EPSAGON') == 'TRUE':
     os.environ['DISABLE_EPSAGON_PATCH'] = 'TRUE'
     lambda_wrapper = dummy_wrapper  # pylint: disable=C0103
     step_lambda_wrapper = dummy_wrapper  # pylint: disable=C0103
+    chalice_wrapper = dummy_wrapper  # pylint: disable=C0103
     azure_wrapper = dummy_wrapper  # pylint: disable=C0103
     python_wrapper = dummy_wrapper  # pylint: disable=C0103
     flask_wrapper = dummy_wrapper  # pylint: disable=C0103
@@ -35,6 +36,7 @@ else:
     from .wrappers import (
         lambda_wrapper,
         step_lambda_wrapper,
+        chalice_wrapper,
         azure_wrapper,
         python_wrapper,
         gcp_wrapper
@@ -51,8 +53,17 @@ else:
 label = trace_factory.add_label
 error = trace_factory.set_error
 
-__all__ = ['lambda_wrapper', 'azure_wrapper', 'python_wrapper', 'init',
-           'step_lambda_wrapper', 'flask_wrapper', 'wrapper', 'gcp_wrapper']
+__all__ = [
+    'lambda_wrapper',
+    'azure_wrapper',
+    'python_wrapper',
+    'init',
+    'step_lambda_wrapper',
+    'flask_wrapper',
+    'wrapper',
+    'gcp_wrapper',
+    'chalice_wrapper',
+]
 
 
 # The modules are patched only if DISABLE_EPSAGON_PATCH variable is NOT 'TRUE'

--- a/epsagon/wrappers/__init__.py
+++ b/epsagon/wrappers/__init__.py
@@ -4,9 +4,16 @@ Wrappers module.
 from __future__ import absolute_import
 
 from .aws_lambda import lambda_wrapper, step_lambda_wrapper
+from .chalice import chalice_wrapper
 from .azure_function import azure_wrapper
 from .python_function import python_wrapper
 from .gcp_function import gcp_wrapper
 
-__all__ = ['lambda_wrapper', 'azure_wrapper', 'python_wrapper',
-           'step_lambda_wrapper', 'gcp_wrapper']
+__all__ = [
+    'lambda_wrapper',
+    'azure_wrapper',
+    'python_wrapper',
+    'step_lambda_wrapper',
+    'gcp_wrapper',
+    'chalice_wrapper',
+]

--- a/epsagon/wrappers/chalice.py
+++ b/epsagon/wrappers/chalice.py
@@ -1,0 +1,31 @@
+"""
+Wrapper for AWS Lambda in Chalice environment.
+"""
+
+from __future__ import absolute_import
+from epsagon.wrappers import lambda_wrapper
+
+
+class ChaliceWrapper:
+    """
+    Class handles wrapping Chalice app.
+    In call we expect an invocation to come, and in getattr we allow `app.attr`
+    calls.
+    """
+    def __init__(self, app):
+        self.app = app
+
+    def __getattr__(self, item):
+        return getattr(self.app, item)
+
+    def __call__(self, *args, **kwargs):
+        return lambda_wrapper(self.app)(*args, **kwargs)
+
+
+def chalice_wrapper(app):
+    """
+    Chalice wrapper
+    :param app: Chalice app
+    :return: ChaliceWrapper
+    """
+    return ChaliceWrapper(app)

--- a/epsagon/wrappers/chalice.py
+++ b/epsagon/wrappers/chalice.py
@@ -3,7 +3,7 @@ Wrapper for AWS Lambda in Chalice environment.
 """
 
 from __future__ import absolute_import
-from epsagon.wrappers import lambda_wrapper
+from . import lambda_wrapper
 
 
 class ChaliceWrapper:
@@ -13,13 +13,13 @@ class ChaliceWrapper:
     calls.
     """
     def __init__(self, app):
-        self.app = app
+        self._app = app
 
     def __getattr__(self, item):
-        return getattr(self.app, item)
+        return getattr(self._app, item)
 
     def __call__(self, *args, **kwargs):
-        return lambda_wrapper(self.app)(*args, **kwargs)
+        return lambda_wrapper(self._app)(*args, **kwargs)
 
 
 def chalice_wrapper(app):

--- a/epsagon/wrappers/chalice.py
+++ b/epsagon/wrappers/chalice.py
@@ -3,7 +3,7 @@ Wrapper for AWS Lambda in Chalice environment.
 """
 
 from __future__ import absolute_import
-from . import lambda_wrapper
+from .aws_lambda import lambda_wrapper
 
 
 class ChaliceWrapper:


### PR DESCRIPTION
this needed since when we wrap the app, the user can't access to `app.attrs` (any attr).