### PR TITLE
fix(flask.py): fix web frameworks tracer and host

### DIFF
--- a/epsagon/modules/tornado.py
+++ b/epsagon/modules/tornado.py
@@ -27,10 +27,13 @@ class TornadoWrapper(object):
         :param kwargs: wrapt's kwargs
         """
         try:
-            epsagon.trace.trace_factory.get_or_create_trace().prepare()
+            trace = epsagon.trace.trace_factory.get_or_create_trace()
+            trace.prepare()
+
             ignored = ignore_request('', instance.request.path)
             if not ignored:
                 cls.RUNNER = TornadoRunner(time.time(), instance.request)
+                trace.set_runner(cls.RUNNER)
         except Exception as instrumentation_exception:  # pylint: disable=W0703
             epsagon.trace.trace_factory.add_exception(
                 instrumentation_exception,

--- a/epsagon/runners/tornado.py
+++ b/epsagon/runners/tornado.py
@@ -29,7 +29,7 @@ class TornadoRunner(BaseEvent):
         self.event_id = str(uuid.uuid4())
 
         # Since Tornado doesn't has app name, we use the tracer app name.
-        self.resource['name'] = request.path
+        self.resource['name'] = request.host
         self.resource['operation'] = request.method
 
         self.resource['metadata'] = {

--- a/epsagon/wrappers/django.py
+++ b/epsagon/wrappers/django.py
@@ -47,7 +47,9 @@ class DjangoMiddleware(object):
         """
         Runs before process of response.
         """
-        epsagon.trace.trace_factory.get_or_create_trace().prepare()
+        trace = epsagon.trace.trace_factory.get_or_create_trace()
+        trace.prepare()
+
         # Ignoring non relevant content types.
         self.ignored_request = ignore_request('', self.request.path.lower())
 
@@ -60,6 +62,7 @@ class DjangoMiddleware(object):
                 time.time(),
                 self.request
             )
+            trace.set_runner(self.runner)
 
             # Collect metadata in case this is a container.
             metadata = collect_container_metadata()

--- a/epsagon/wrappers/flask.py
+++ b/epsagon/wrappers/flask.py
@@ -70,6 +70,7 @@ class FlaskWrapper(object):
                 self.app,
                 request
             )
+            trace.set_runner(self.runner)
 
             # Collect metadata in case this is a container.
             metadata = collect_container_metadata()


### PR DESCRIPTION
Fixing host as resource name for Tornado, and set runner for all web frameworks