### PR TITLE
fix(flask.py): fix web frameworks sending two runners

### DIFF
--- a/epsagon/modules/tornado.py
+++ b/epsagon/modules/tornado.py
@@ -59,7 +59,6 @@ class TornadoWrapper(object):
             ignored = ignore_request(content, '')
             if not ignored and cls.RUNNER:
                 cls.RUNNER.update_response(instance)
-                trace.add_event(cls.RUNNER)
                 trace.send_traces()
             trace.prepare()
         except Exception as instrumentation_exception:  # pylint: disable=W0703

--- a/epsagon/wrappers/django.py
+++ b/epsagon/wrappers/django.py
@@ -105,6 +105,5 @@ class DjangoMiddleware(object):
             self.ignored_request = True
             return
 
-        epsagon.trace.trace_factory.add_event(self.runner)
         self.runner.update_response(self.response)
         epsagon.trace.trace_factory.send_traces()

--- a/epsagon/wrappers/flask.py
+++ b/epsagon/wrappers/flask.py
@@ -162,6 +162,5 @@ class FlaskWrapper(object):
             return
 
         trace = epsagon.trace.trace_factory.get_or_create_trace()
-        trace.add_event(self.runner)
         trace.send_traces()
         trace.prepare()

--- a/tests/wrappers/test_flask_wrapper.py
+++ b/tests/wrappers/test_flask_wrapper.py
@@ -61,7 +61,7 @@ def test_flask_wrapper_after_request(runner_mock, _, client):
 def test_flask_wrapper_teardown_request(trace_mock, _, client):
     """Test tracer gets new event and send it on new request."""
     client.get('/')
-    trace_mock().add_event.assert_called_once()
+    trace_mock().set_runner.assert_called_once()
     trace_mock().send_traces.assert_called_once()
 
 


### PR DESCRIPTION
Already added in set_runner