### PR TITLE
fix(tornado.py): change finish wrapper

### DIFF
--- a/epsagon/constants.py
+++ b/epsagon/constants.py
@@ -2,7 +2,7 @@
 
 import os
 
-__version__ = '1.0.54'
+__version__ = '0.0.0-dev'
 
 DEFAULT_REGION = 'us-east-1'
 REGION = os.getenv('AWS_REGION', DEFAULT_REGION)

--- a/epsagon/modules/tornado.py
+++ b/epsagon/modules/tornado.py
@@ -103,7 +103,7 @@ def patch():
     )
     wrapt.wrap_function_wrapper(
         'tornado.web',
-        'RequestHandler.on_finish',
+        'RequestHandler.finish',
         TornadoWrapper.after_request
     )
     wrapt.wrap_function_wrapper(

--- a/epsagon/runners/tornado.py
+++ b/epsagon/runners/tornado.py
@@ -64,5 +64,5 @@ class TornadoRunner(BaseEvent):
         self.resource['metadata']['Status'] = response._status_code
         self.resource['metadata']['etag'] = headers.get('Etag')
 
-        if not self.error_code and response._status_code >= 300:
+        if not self.error_code and response._status_code >= 500:
             self.set_error()


### PR DESCRIPTION
using `finish` instead of `on_finish`.
Also reporting errors only on >=500.
And setting the local version to be 0.0.0-dev (used only in local tests).