### PR TITLE
fix(http): allow custom error code

### DIFF
--- a/epsagon/constants.py
+++ b/epsagon/constants.py
@@ -21,4 +21,4 @@ SEND_TIMEOUT = TIMEOUT_ENV if TIMEOUT_ENV else TIMEOUT_GRACE_TIME_MS / 1000.0
 MAX_LABEL_SIZE = 100 * 1024
 
 # User-defined HTTP minimum status code to be treated as an error.
-HTTP_ERR_CODE = int(os.getenv('EPSAGON_HTTP_ERR_CODE', 500))
+HTTP_ERR_CODE = int(os.getenv('EPSAGON_HTTP_ERR_CODE', '500'))

--- a/epsagon/constants.py
+++ b/epsagon/constants.py
@@ -19,3 +19,6 @@ TIMEOUT_ENV = float(os.getenv('EPSAGON_SEND_TIMEOUT_SEC', '0'))
 SEND_TIMEOUT = TIMEOUT_ENV if TIMEOUT_ENV else TIMEOUT_GRACE_TIME_MS / 1000.0
 
 MAX_LABEL_SIZE = 100 * 1024
+
+# User-defined HTTP minimum status code to be treated as an error.
+HTTP_ERR_CODE = int(os.getenv('EPSAGON_HTTP_ERR_CODE', 500))

--- a/epsagon/events/httplib2.py
+++ b/epsagon/events/httplib2.py
@@ -19,6 +19,7 @@ from ..wrappers.http_filters import (
     is_payload_collection_blacklisted
 )
 from ..utils import update_api_gateway_headers
+from ..constants import HTTP_ERR_CODE
 
 
 class Httplib2Event(BaseEvent):
@@ -116,7 +117,7 @@ class Httplib2Event(BaseEvent):
                 pass
 
         # Detect errors based on status code
-        if int(response_headers['status']) >= 300:
+        if int(response_headers['status']) >= HTTP_ERR_CODE:
             self.set_error()
 
     @staticmethod

--- a/epsagon/events/requests.py
+++ b/epsagon/events/requests.py
@@ -13,6 +13,7 @@ from ..trace import trace_factory
 from ..event import BaseEvent
 from ..wrappers.http_filters import is_blacklisted_url
 from ..utils import update_api_gateway_headers, normalize_http_url
+from ..constants import HTTP_ERR_CODE
 
 
 class RequestsEvent(BaseEvent):
@@ -94,7 +95,7 @@ class RequestsEvent(BaseEvent):
             pass
 
         # Detect errors based on status code
-        if response.status_code >= 300:
+        if response.status_code >= HTTP_ERR_CODE:
             self.set_error()
 
 

--- a/epsagon/events/urllib.py
+++ b/epsagon/events/urllib.py
@@ -15,6 +15,7 @@ from ..wrappers.http_filters import (
     is_payload_collection_blacklisted
 )
 from ..utils import update_api_gateway_headers, normalize_http_url
+from ..constants import HTTP_ERR_CODE
 
 
 class UrllibEvent(BaseEvent):
@@ -102,7 +103,7 @@ class UrllibEvent(BaseEvent):
                 pass
 
         # Detect errors based on status code
-        if response.status >= 300:
+        if response.status >= HTTP_ERR_CODE:
             self.set_error()
 
 

--- a/epsagon/events/urllib3.py
+++ b/epsagon/events/urllib3.py
@@ -19,6 +19,7 @@ from ..wrappers.http_filters import (
     is_payload_collection_blacklisted
 )
 from ..utils import update_api_gateway_headers, normalize_http_url
+from ..constants import HTTP_ERR_CODE
 
 
 class Urllib3Event(BaseEvent):
@@ -110,7 +111,7 @@ class Urllib3Event(BaseEvent):
             )
 
         # Detect errors based on status code
-        if response.status >= 300:
+        if response.status >= HTTP_ERR_CODE:
             self.set_error()
 
 
@@ -125,7 +126,6 @@ class Urllib3EventFactory(object):
         """
         Create an event according to the given api_name.
         """
-        # pylint: disable=possibly-unused-variable
         path = args[1] if len(args) > 1 else kwargs.get('url', '')
         port_part = ':' + str(instance.port) if instance.port else ''
         host_url = '{}://{}'.format(instance.scheme, instance.host)

--- a/epsagon/modules/tornado.py
+++ b/epsagon/modules/tornado.py
@@ -17,8 +17,6 @@ class TornadoWrapper(object):
     Wraps Tornado web framework to get requests.
     """
     RUNNER = None
-    ECS_TASK_METADATA = None
-    CHECKED_ECS_ENDPOINT = False
 
     @classmethod
     def before_request(cls, wrapped, instance, args, kwargs):
@@ -39,13 +37,9 @@ class TornadoWrapper(object):
                 trace.set_runner(cls.RUNNER)
 
                 # Collect metadata in case this is a container.
-                if not cls.CHECKED_ECS_ENDPOINT:
-                    cls.CHECKED_ECS_ENDPOINT = True
-                    cls.ECS_TASK_METADATA = collect_container_metadata()
-                if cls.ECS_TASK_METADATA:
-                    cls.RUNNER.resource['metadata']['ECS'] = (
-                        cls.ECS_TASK_METADATA
-                    )
+                metadata = collect_container_metadata()
+                if metadata:
+                    cls.RUNNER.resource['metadata']['ECS'] = metadata
         except Exception as instrumentation_exception:  # pylint: disable=W0703
             epsagon.trace.trace_factory.add_exception(
                 instrumentation_exception,

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -342,6 +342,7 @@ class Trace(object):
                 self.timeout_handler
             )
 
+            # pylint: disable=comparison-with-callable
             if (
                     original_handler and
                     original_handler != self.timeout_handler

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -342,7 +342,6 @@ class Trace(object):
                 self.timeout_handler
             )
 
-            # pylint: disable=comparison-with-callable
             if (
                     original_handler and
                     original_handler != self.timeout_handler

--- a/epsagon/utils.py
+++ b/epsagon/utils.py
@@ -16,6 +16,12 @@ from .trace import trace_factory
 from .constants import EPSAGON_HANDLER
 
 
+METADATA_CACHE = {
+    'queried': False,
+    'data': {},
+}
+
+
 def normalize_http_url(url):
     """
     Strip http schema, port number and path from a url
@@ -162,6 +168,10 @@ def collect_container_metadata():
     Collects container metadata if exists.
     :return: dict.
     """
+    if METADATA_CACHE['queried']:
+        return METADATA_CACHE['data']
+
+    METADATA_CACHE['queried'] = True
     metadata_uri = os.environ.get('ECS_CONTAINER_METADATA_URI')
     if not metadata_uri:
         return {}
@@ -169,4 +179,5 @@ def collect_container_metadata():
 
     new_metadata = container_metadata['Labels'].copy()
     new_metadata['Limits'] = container_metadata['Limits']
-    return new_metadata
+    METADATA_CACHE['data'] = new_metadata
+    return METADATA_CACHE['data']

--- a/epsagon/utils.py
+++ b/epsagon/utils.py
@@ -167,10 +167,6 @@ def collect_container_metadata():
         return {}
     container_metadata = json.loads(requests.get(metadata_uri).content)
 
-    # Remove event from events list
-    events = list(trace_factory.get_trace().events_map.keys())
-    trace_factory.get_trace().events_map.pop(events[0])
-
     new_metadata = container_metadata['Labels'].copy()
     new_metadata['Limits'] = container_metadata['Limits']
     return new_metadata

--- a/epsagon/wrappers/flask.py
+++ b/epsagon/wrappers/flask.py
@@ -48,6 +48,7 @@ class FlaskWrapper(object):
 
         # Whether we ignore this request or not.
         self.ignored_request = False
+        epsagon.trace.trace_factory.switch_to_multiple_traces()
 
     def _before_request(self):
         """

--- a/epsagon/wrappers/http_filters.py
+++ b/epsagon/wrappers/http_filters.py
@@ -32,6 +32,7 @@ BLACKLIST_URLS = {
     ],
     str.__contains__: [
         'accounts.google.com',
+        '169.254.170.2'  # AWS Task Metadata Endpoint
     ],
 }
 WHITELIST_URL = {

--- a/epsagon/wrappers/python_function.py
+++ b/epsagon/wrappers/python_function.py
@@ -30,13 +30,13 @@ def wrap_python_function(func, args, kwargs):
             args,
             kwargs
         )
+        epsagon.trace.trace_factory.set_runner(runner)
 
         # Collect metadata in case this is a container.
         metadata = collect_container_metadata()
         if metadata:
             runner.resource['metadata']['ECS'] = metadata
 
-        epsagon.trace.trace_factory.set_runner(runner)
     # pylint: disable=W0703
     except Exception:
         # If we failed, just call the user's function. Nothing more to do.

--- a/tests/wrappers/test_flask_wrapper.py
+++ b/tests/wrappers/test_flask_wrapper.py
@@ -79,5 +79,5 @@ def test_flask_wrapper_teardown_exception(exception_mock, _, client):
     'epsagon.trace.trace_factory.get_or_create_trace',
     side_effect=lambda: trace_mock
 )
-def test_lambda_wrapper_single_thread(_):
-    assert trace_factory.use_single_trace
+def test_lambda_wrapper_multi_thread(_):
+    assert not trace_factory.use_single_trace

--- a/tests/wrappers/test_lambda_wrapper.py
+++ b/tests/wrappers/test_lambda_wrapper.py
@@ -13,6 +13,7 @@ trace_mock = mock.MagicMock()
 
 
 def setup_function(func):
+    trace_factory.use_single_trace = True
     trace_mock.configure_mock(**get_tracer_patch_kwargs())
     epsagon.constants.COLD_START = True
 

--- a/tests/wrappers/test_python_function.py
+++ b/tests/wrappers/test_python_function.py
@@ -14,10 +14,8 @@ trace_mock = mock.MagicMock()
 
 def setup_function(func):
     trace_mock.configure_mock(**get_tracer_patch_kwargs())
-    if trace_factory.use_single_trace:
-        trace_factory.singleton_trace = trace_mock
-    else:
-        trace_factory.traces[threading.currentThread().ident] = trace_mock
+    trace_factory.singleton_trace = trace_mock
+    trace_factory.use_single_trace = True
     epsagon.constants.COLD_START = True
 
 


### PR DESCRIPTION
In addition:
1. Changed multiple tracers in Flask. This caused some other unrelated tests to break, since tracer_factory is global. Fixed.
2. Collect ECS task metadata in tornado.
3. Fixed task metadata event removal. which caused runner removal.