### PR TITLE
fix(botocore.py): fix DynamoDB conditions formatting

### DIFF
--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -707,7 +707,11 @@ class Trace(object):
         """
         for event in sorted(list(self.events()), key=Trace.events_sorter):
             event_metadata_length = (
-                    len(json.dumps(event.resource.get('metadata', {})))
+                len(json.dumps(
+                    event.resource.get('metadata', {}),
+                    cls=TraceEncoder,
+                    encoding='latin1',
+                ))
             )
             Trace.trim_metadata(event.resource['metadata'])
             trace_length -= event_metadata_length


### PR DESCRIPTION
conditions will be formatted using the built-in boto3 lib, like:
```
BuiltConditionExpression(condition_expression='(#n0 = :v0 AND #n1 = :v1)', attribute_name_placeholders={'#n0': 'main', '#n1': 'uniqueId'}, attribute_value_placeholders={':v0': 'order', ':v1': 1})
```