### PR TITLE
fix(triggers): support api gateway mapping templates

### DIFF
--- a/epsagon/triggers/aws_lambda.py
+++ b/epsagon/triggers/aws_lambda.py
@@ -265,19 +265,33 @@ class ProxyAPIGatewayLambdaTrigger(BaseLambdaTrigger):
         """
 
         super(ProxyAPIGatewayLambdaTrigger, self).__init__(start_time)
-
-        self.event_id = event['requestContext']['requestId']
+        default_request_context = {
+            'requestId': uuid4(),
+            'apiId': 'N/A',
+            'stage': event.get('environment', 'N/A')
+        }
+        request_context = event.get('requestContext', default_request_context)
+        self.event_id = request_context['requestId']
         self.resource['name'] = event['headers'].get(
             'Host',
-            event['requestContext']['apiId']
+            request_context.get('apiId')
         )
 
         self.resource['operation'] = event['httpMethod']
 
+        query_params = event.get(
+            'queryStringParameters',
+            event.get('queryParams', 'N/A')
+        )
+        path_params = event.get(
+            'pathParameters',
+            event.get('pathParams', 'N/A')
+        )
+
         self.resource['metadata'] = {
-            'stage': event['requestContext']['stage'],
-            'query_string_parameters': event['queryStringParameters'],
-            'path_parameters': event['pathParameters'],
+            'stage': request_context.get('stage', 'N/A'),
+            'query_string_parameters': query_params,
+            'path_parameters': path_params,
             'path': event['resource'],
         }
 


### PR DESCRIPTION
Add support for the following API Gateway mapping template:
```{
  "operation": "GetViews",
  "httpMethod": "$context.httpMethod",
  "environment": "$stageVariables.environment",
  "body" : $input.json("$"),
  "identity": {
      #foreach($key in $context.identity.keySet())
          "$key": "$context.identity.get($key)"
      #if($foreach.hasNext), #end
      #end
  },
  "headers": {
    #foreach($param in $input.params().header.keySet())
      "$param": "$util.escapeJavaScript($input.params().header.get($param))"
      #if($foreach.hasNext),
      #end
    #end
  },
  "queryParams": {
    #foreach($param in $input.params().querystring.keySet())
      "$param": "$util.escapeJavaScript($input.params().querystring.get($param))"
      #if($foreach.hasNext),
      #end
    #end
  },
  "pathParams": {
    #foreach($param in $input.params().path.keySet())
      "$param": "$util.urlDecode($util.escapeJavaScript($input.params().path.get($param)))"
      #if($foreach.hasNext),
      #end
    #end
  }
}`