### PR TITLE
fix(pynamodb.py): update support for pynamodb 4

### DIFF
--- a/epsagon/events/botocore.py
+++ b/epsagon/events/botocore.py
@@ -90,7 +90,10 @@ class BotocoreEvent(BaseEvent):
         )
 
         # Specific handling for botocore errors
-        if isinstance(exception, ClientError):
+        if (
+            isinstance(exception, ClientError) and
+            'ResponseMetadata' in exception.response
+        ):
             self.event_id = exception.response['ResponseMetadata']['RequestId']
             botocore_error = exception.response['Error']
             self.resource['metadata']['botocore_error'] = True

--- a/epsagon/events/pynamodb.py
+++ b/epsagon/events/pynamodb.py
@@ -76,7 +76,7 @@ class PynamoDBEventAdapter(object):
         new_response = {
             'ResponseMetadata': {
                 'RequestId': 'pynamodb-{}'.format(str(uuid4())),
-                'HTTPStatusCode': 200,
+                'HTTPStatusCode': 200 if exception is None else 500,
                 'RetryAttempts': None,
             },
         }

--- a/epsagon/events/pynamodb.py
+++ b/epsagon/events/pynamodb.py
@@ -80,7 +80,8 @@ class PynamoDBEventAdapter(object):
                 'RetryAttempts': None,
             },
         }
-        new_response.update(response)
+        if response:
+            new_response.update(response)
         event = BotocoreDynamoDBEvent(
             wrapped,
             instance.client,

--- a/epsagon/events/urllib3.py
+++ b/epsagon/events/urllib3.py
@@ -131,6 +131,15 @@ class Urllib3EventFactory(object):
         """
         Create an event according to the given api_name.
         """
+        # Ignore requests events since they are being instrumented.
+        is_requests = (
+            str(kwargs.get('headers', {}).get('User-Agent', '')).startswith(
+                'python-requests'
+            )
+        )
+        if is_requests:
+            return
+
         path = args[1] if len(args) > 1 else kwargs.get('url', '')
         port_part = ':' + str(instance.port) if instance.port else ''
         host_url = '{}://{}'.format(instance.scheme, instance.host)

--- a/epsagon/modules/pynamodb.py
+++ b/epsagon/modules/pynamodb.py
@@ -5,10 +5,10 @@ PynamoDB patcher module.
 from __future__ import absolute_import
 import wrapt
 from epsagon.modules.general_wrapper import wrapper
-from ..events.pynamodb import PynamoDBEventAdapter
+from ..events.pynamodb import PynamoDBEventAdapter, PynamoDBVendoredEventAdapter
 
 
-def _wrapper(wrapped, instance, args, kwargs):
+def _vendored_wrapper(wrapped, instance, args, kwargs):
     """
     General wrapper for PynamoDB instrumentation.
     :param wrapped: wrapt's wrapped
@@ -22,6 +22,24 @@ def _wrapper(wrapped, instance, args, kwargs):
     if 'https://dynamodb.' not in args[0].url:
         return wrapped(*args, **kwargs)
 
+    return wrapper(
+        PynamoDBVendoredEventAdapter,
+        wrapped,
+        instance,
+        args,
+        kwargs
+    )
+
+
+def _wrapper(wrapped, instance, args, kwargs):
+    """
+    General wrapper for PynamoDB instrumentation.
+    :param wrapped: wrapt's wrapped
+    :param instance: wrapt's instance
+    :param args: wrapt's args
+    :param kwargs: wrapt's kwargs
+    :return: None
+    """
     return wrapper(PynamoDBEventAdapter, wrapped, instance, args, kwargs)
 
 
@@ -30,9 +48,20 @@ def patch():
     Patch module.
     :return: None
     """
+    try:
+        wrapt.wrap_function_wrapper(
+            'pynamodb.connection.base',
+            'Connection._make_api_call',
+            _wrapper
+        )
+    except AttributeError:
+        pass
 
-    wrapt.wrap_function_wrapper(
-        'botocore.vendored.requests.sessions',
-        'Session.send',
-        _wrapper
-    )
+    try:
+        wrapt.wrap_function_wrapper(
+            'botocore.vendored.requests.sessions',
+            'Session.send',
+            _vendored_wrapper
+        )
+    except AttributeError:
+        pass

--- a/epsagon/modules/requests.py
+++ b/epsagon/modules/requests.py
@@ -8,6 +8,7 @@ botocore module that has a similar interface.
 """
 
 from __future__ import absolute_import
+import wrapt
 from epsagon.modules.general_wrapper import wrapper
 from ..events.requests import RequestsEventFactory
 
@@ -21,7 +22,6 @@ def _wrapper(wrapped, instance, args, kwargs):
     :param kwargs: wrapt's kwargs
     :return: None
     """
-
     return wrapper(RequestsEventFactory, wrapped, instance, args, kwargs)
 
 
@@ -31,8 +31,8 @@ def patch():
     :return: None
     """
 
-    # wrapt.wrap_function_wrapper(
-    #     'requests',
-    #     'Session.send',
-    #     _wrapper
-    # )
+    wrapt.wrap_function_wrapper(
+        'requests',
+        'Session.send',
+        _wrapper
+    )


### PR DESCRIPTION
The new version of pynamodb is no longer using `botocore.vendored.requests`.
In addition, putting back instrumentation for requests library, since it captures also the payload (which we can't in urllib3).