### PR TITLE
feat(django): prevent epsagon from sending tracing to paths in django

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ MIDDLEWARE = [
 ]
 ```
 
+Use ignored_endpoints to blacklist specific paths and prevent Epsagon from sending a trace.
+```python
+import epsagon
+epsagon.init(
+    ...
+    ignored_endpoints=['/path', '/path/to/ignore']
+)
+```
+
 ### Flask Application
 
 Use the example snippet:

--- a/epsagon/wrappers/django.py
+++ b/epsagon/wrappers/django.py
@@ -39,15 +39,16 @@ class DjangoMiddleware(object):
 
     def __call__(self, request):
         self.request = request
-
-        # Link epsagon to the request object for easy-access to epsagon library.
-        self.request.epsagon = epsagon
-        self._before_request()
-
+        is_ignored_endpoint = epsagon.http_filters.is_ignored_endpoint(
+            self.request.path
+        )
+        if not is_ignored_endpoint:
+            # Link epsagon to the request object for easy-access to epsagon lib
+            self.request.epsagon = epsagon
+            self._before_request()
         self.response = self.get_response(request)
-
-        self._after_request()
-
+        if not is_ignored_endpoint:
+            self._after_request()
         return self.response
 
     def _before_request(self):


### PR DESCRIPTION
Use ignored_endpoints to blacklist specific paths and prevent Epsagon from sending a trace.
