### PR TITLE
feat(allow-whitelist-keys): allow whitelist keys in metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,16 +167,19 @@ AUTOWRAPT_BOOTSTRAP=epsagon python app.py
 You can customize your library usage using flags. The flags
 should be set as enviroment variables in your code runtime enviroment.
 
-```EPSAGON_SEND_TIMEOUT_SEC``` - Set a custom trace send timeout.<br /> 
-```EPSAGON_HTTP_ERR_CODE``` - Minimum HTTP status to be treated as an error.<br /> 
-```EPSAGON_SSL``` - TRUE / FALSE. Disable SSL for trace send. Default is TRUE.<br /> 
-```EPSAGON_ENDPOINTS_TO_IGNORE``` - Endpoints to ignore, comma seperated. aka: "endpoint1, endpoint2"<br /> 
-```EPSAGON_TOKEN``` - Account Epsagon token.<br /> 
-```EPSAGON_APP_NAME``` - Application name that will be set for traces.<br /> 
-```EPSAGON_METADATA``` - TRUE / FALSE. Whether to send all collected data, or just metadata. Default is FALSE.<br /> 
-```EPSAGON_SPLIT_ON_SEND``` - TRUE / FALSE. Split big traces into multiple parts. Default is FALSE.<br /> 
-```EPSAGON_IGNORED_KEYS``` - TRUE / FALSE. Prevent data from being sent to epsagon by filtering specific keys in initialization. Default is FALSE.<br /> 
-```EPSAGON_ALLOWED_KEYS``` - TRUE / FALSE. Allow data to be sent to epsagon by filtering specific keys in initialization. Default is FALSE.
+| Parameter                   | Type    | Default | Description                                                                                             |   |
+|-----------------------------|---------|---------|---------------------------------------------------------------------------------------------------------|---|
+| EPSAGON_SEND_TIMEOUT_SEC    | String  | 0       | Set a custom trace send timeout                                                                         |   |
+| EPSAGON_HTTP_ERR_CODE       | String  | 500     | Minimum HTTP status to be treated as an error                                                           |   |
+| EPSAGON_SSL                 | Boolean | TRUE    | Disable SSL for trace send                                                                              |   |
+| EPSAGON_ENDPOINTS_TO_IGNORE | String  | None    | Endpoints to ignore, comma seperated. aka: "endpoint1, endpoint2"                                       |   |
+| EPSAGON_TOKEN               | String  | None    | Account Epsagon token                                                                                   |   |
+| EPSAGON_APP_NAME            | String  | None    | Application name that will be set for traces                                                            |   |
+| EPSAGON_METADATA            | Boolean | FALSE   | Whether to send all collected data, or just metadata                                                    |   |
+| EPSAGON_SPLIT_ON_SEND       | Boolean | FALSE   | Split big traces into multiple parts                                                                    |   |
+| EPSAGON_IGNORED_KEYS        | String  | None    | Prevent data from being sent to epsagon by filtering specific keys in initialization. aka: "key1, key2" |   |
+| EPSAGON_ALLOWED_KEYS        | String  | None    | Allow data to be sent to epsagon by filtering specific keys in initialization.aka: "key1, key2"         |   |
+
 
 ### Lambda specific flags
 EPSAGON_DISABLE_ON_TIMEOUT - TRUE / FALSE. Don't send trace on timeout. Default is FALSE.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,21 @@ epsagon.init(
     keys_to_ignore=['Request Data', 'Status_Code']
 )
 ```
+
+### Allow keys
+You can allow data to be sent to epsagon by filtering specific keys in initialization.
+￿￿Only branches which contains allow keys will be sent.
+
+```python
+import epsagon
+epsagon.init(
+    token='my-secret-token',
+    app_name='my-app-name',
+    metadata_only=False,
+    keys_to_allow=['Request Data', 'Status_Code']
+)
+```
+
 ## Frameworks Integration
 
 When using any of the following integrations, make sure to add `epsagon` under your `requirements.txt` file.

--- a/README.md
+++ b/README.md
@@ -167,14 +167,16 @@ AUTOWRAPT_BOOTSTRAP=epsagon python app.py
 You can customize your library usage using flags. The flags
 should be set as enviroment variables in your code runtime enviroment.
 
-EPSAGON_SEND_TIMEOUT_SEC - Set a custom trace send timeout.
-EPSAGON_HTTP_ERR_CODE - Minimum HTTP status to be treated as an error.
-EPSAGON_SSL - TRUE / FALSE. Disable SSL for trace send. Default is TRUE.
-EPSAGON_ENDPOINTS_TO_IGNORE - Endpoints to ignore, comma seperated. aka: "endpoint1, endpoint2"
-EPSAGON_TOKEN - Account Epsagon token.
-EPSAGON_APP_NAME - Application name that will be set for traces.
-EPSAGON_METADATA - TRUE / FALSE. Whether to send all collected data, or just metadata. Default is FALSE.
-EPSAGON_SPLIT_ON_SEND - TRUE / FALSE. Split big traces into multiple parts. Default is FALSE.
+```EPSAGON_SEND_TIMEOUT_SEC``` - Set a custom trace send timeout.<br /> 
+```EPSAGON_HTTP_ERR_CODE``` - Minimum HTTP status to be treated as an error.<br /> 
+```EPSAGON_SSL``` - TRUE / FALSE. Disable SSL for trace send. Default is TRUE.<br /> 
+```EPSAGON_ENDPOINTS_TO_IGNORE``` - Endpoints to ignore, comma seperated. aka: "endpoint1, endpoint2"<br /> 
+```EPSAGON_TOKEN``` - Account Epsagon token.<br /> 
+```EPSAGON_APP_NAME``` - Application name that will be set for traces.<br /> 
+```EPSAGON_METADATA``` - TRUE / FALSE. Whether to send all collected data, or just metadata. Default is FALSE.<br /> 
+```EPSAGON_SPLIT_ON_SEND``` - TRUE / FALSE. Split big traces into multiple parts. Default is FALSE.<br /> 
+```EPSAGON_IGNORED_KEYS``` - TRUE / FALSE. Prevent data from being sent to epsagon by filtering specific keys in initialization. Default is FALSE.<br /> 
+```EPSAGON_ALLOWED_KEYS``` - TRUE / FALSE. Allow data to be sent to epsagon by filtering specific keys in initialization. Default is FALSE.
 
 ### Lambda specific flags
 EPSAGON_DISABLE_ON_TIMEOUT - TRUE / FALSE. Don't send trace on timeout. Default is FALSE.
@@ -232,7 +234,7 @@ epsagon.init(
 ### Allowed keys
 You can allow data to be sent to epsagon by filtering specific keys in initialization.
 Only keys included in this list will be sent to epsagon.
-Good to know - keys_to_ignore is stronger then keys_to_allow if you use both.
+NOTE - Keys found in keys_to_ignore override this setting
 
 ```python
 import epsagon

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ def handler(event, context):
 
 You can prevent data from being sent to epsagon by filtering specific keys in initialization.
 ```python
+
 import epsagon
 epsagon.init(
     token='my-secret-token',
@@ -228,9 +229,10 @@ epsagon.init(
 )
 ```
 
-### Allow keys
+### Allowed keys
 You can allow data to be sent to epsagon by filtering specific keys in initialization.
-￿￿Only branches which contains allow keys will be sent.
+Only keys included in this list will be sent to epsagon.
+Good to know - keys_to_ignore is stronger then keys_to_allow if you use both.
 
 ```python
 import epsagon

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -990,10 +990,12 @@ class Trace(object):
             else create_transport(self.collector_url, self.token)
         )
 
-        # Remove ignored keys.
+        # Update events resource metadata.
         for event in self.events:
+            # Remove ignored keys.
             event.resource['metadata'] = self.remove_ignored_keys(
                 event.resource['metadata'])
+            # Keep allowed keys.
             if self.keys_to_allow:
                 event.resource['metadata'] = self.get_dict_with_allow_keys(
                     event.resource['metadata'])

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -476,7 +476,8 @@ class Trace(object):
         self.propagate_lambda_id = propagate_lambda_id
 
         if keys_to_ignore:
-            self.keys_to_ignore = [self._strip_key(x) for x in keys_to_ignore]
+            self.keys_to_ignore = [self._strip_key(key) for key in
+                                   keys_to_ignore]
             if self.debug:
                 print(
                     'Setting keys_to_ignore={}'.format(keys_to_ignore)
@@ -484,7 +485,7 @@ class Trace(object):
         else:
             self.keys_to_ignore = []
         if keys_to_allow:
-            self.keys_to_allow = [self._strip_key(x) for x in keys_to_allow]
+            self.keys_to_allow = [self._strip_key(key) for key in keys_to_allow]
             if self.debug:
                 print(
                     'Setting keys_to_allow={}'.format(keys_to_allow)
@@ -991,11 +992,11 @@ class Trace(object):
 
         # Remove ignored keys.
         for event in self.events:
+            event.resource['metadata'] = self.remove_ignored_keys(
+                event.resource['metadata'])
             if self.keys_to_allow:
                 event.resource['metadata'] = self.get_dict_with_allow_keys(
                     event.resource['metadata'])
-            event.resource['metadata'] = self.remove_ignored_keys(
-                event.resource['metadata'])
             type(self)._trim_dict_values(
                 event.resource['metadata'],
                 MAX_METADATA_FIELD_SIZE_LIMIT

--- a/epsagon/utils.py
+++ b/epsagon/utils.py
@@ -92,6 +92,7 @@ def init(
     send_trace_only_on_error=False,
     url_patterns_to_ignore=None,
     keys_to_ignore=None,
+    keys_to_allow=None,
     ignored_endpoints=None,
     split_on_send=False,
     propagate_lambda_id=False,
@@ -112,6 +113,7 @@ def init(
     :param url_patterns_to_ignore: URL patterns to ignore in HTTP data
       collection.
     :param keys_to_ignore: List of keys to ignore while extracting metadata.
+    :param keys_to_allow: List of keys to allow while extracting metadata
     :param ignored_endpoints: List of ignored endpoints for web frameworks.
     :param split_on_send: Split the trace on send flag
     :param propagate_lambda_id: Inject identifiers via return value flag
@@ -137,6 +139,10 @@ def init(
     if ignored_keys:
         ignored_keys = ignored_keys.split(',')
 
+    allowed_keys = os.getenv('EPSAGON_ALLOWED_KEYS')
+    if allowed_keys:
+        allowed_keys = allowed_keys.split(',')
+
     trace_factory.initialize(
         token=os.getenv('EPSAGON_TOKEN') or token,
         app_name=os.getenv('EPSAGON_APP_NAME') or app_name,
@@ -159,6 +165,7 @@ def init(
         ),
         url_patterns_to_ignore=ignored_urls or url_patterns_to_ignore,
         keys_to_ignore=ignored_keys or keys_to_ignore,
+        keys_to_allow=allowed_keys or keys_to_allow,
         transport=create_transport(collector_url, token),
         split_on_send=(
                 ((os.getenv('EPSAGON_SPLIT_ON_SEND') or '').upper() == 'TRUE')

--- a/tests/test_epsagon_init.py
+++ b/tests/test_epsagon_init.py
@@ -74,6 +74,7 @@ def test_epsagon_disable_epsagon_and_disable_patch(wrapped_get, wrapped_patch):
     'EPSAGON_URLS_TO_IGNORE': '',
     'EPSAGON_ENDPOINTS_TO_IGNORE': '',
     'EPSAGON_IGNORED_KEYS': '',
+    'EPSAGON_ALLOWED_KEYS': '',
 }[x]))
 def test_epsagon_wrapper_env_init(wrapped_get):
     reload(epsagon)
@@ -84,6 +85,7 @@ def test_epsagon_wrapper_env_init(wrapped_get):
         mock.call('EPSAGON_URLS_TO_IGNORE'),
         mock.call('EPSAGON_ENDPOINTS_TO_IGNORE'),
         mock.call('EPSAGON_IGNORED_KEYS'),
+        mock.call('EPSAGON_ALLOWED_KEYS'),
         mock.call('EPSAGON_TOKEN'),
         mock.call('EPSAGON_APP_NAME'),
         mock.call('EPSAGON_COLLECTOR_URL'),
@@ -98,6 +100,7 @@ def test_epsagon_wrapper_env_init(wrapped_get):
         mock.call('EPSAGON_URLS_TO_IGNORE'),
         mock.call('EPSAGON_ENDPOINTS_TO_IGNORE'),
         mock.call('EPSAGON_IGNORED_KEYS'),
+        mock.call('EPSAGON_ALLOWED_KEYS'),
         mock.call('EPSAGON_TOKEN'),
         mock.call('EPSAGON_APP_NAME'),
         mock.call('EPSAGON_COLLECTOR_URL'),
@@ -128,6 +131,7 @@ default_http = HTTPTransport("epsagon", "1234")
     'EPSAGON_SEND_TRACE_ON_ERROR': 'FALSE',
     'EPSAGON_URLS_TO_IGNORE': '',
     'EPSAGON_IGNORED_KEYS': '',
+    'EPSAGON_ALLOWED_KEYS': '',
     'EPSAGON_LOG_TRANSPORT': 'FALSE',
     'EPSAGON_ENDPOINTS_TO_IGNORE': '',
     'EPSAGON_SPLIT_ON_SEND': 'FALSE',
@@ -146,6 +150,7 @@ def test_epsagon_wrapper_env_init(_wrapped_get, wrapped_init, _create):
         send_trace_only_on_error=False,
         url_patterns_to_ignore=None,
         keys_to_ignore=None,
+        keys_to_allow=None,
         transport=default_http,
         split_on_send=False,
         propagate_lambda_id=False,
@@ -167,6 +172,7 @@ def test_epsagon_wrapper_env_init(_wrapped_get, wrapped_init, _create):
     'EPSAGON_SEND_TRACE_ON_ERROR': 'FALSE',
     'EPSAGON_URLS_TO_IGNORE': '',
     'EPSAGON_IGNORED_KEYS': '',
+    'EPSAGON_ALLOWED_KEYS': '',
     'EPSAGON_ENDPOINTS_TO_IGNORE': '/health,/test',
     'EPSAGON_LOG_TRANSPORT': 'FALSE',
     'EPSAGON_SPLIT_ON_SEND': 'FALSE',


### PR DESCRIPTION
Filtering resource metadata by allows keys, Only branches that contain keys from keys_to_allow will be sent to epsagon.
