### PR TITLE
fix(trace.py): remove EpsagonException

### DIFF
--- a/epsagon/common.py
+++ b/epsagon/common.py
@@ -15,9 +15,3 @@ class EpsagonWarning(Warning):
     """
     An Epsagon warning.
     """
-
-
-class EpsagonException(Exception):
-    """
-    An Epsagon exception.
-    """

--- a/epsagon/event.py
+++ b/epsagon/event.py
@@ -96,13 +96,20 @@ class BaseEvent(object):
         if self.error_code != ErrorCode.EXCEPTION:
             self.error_code = ErrorCode.ERROR
 
-    def set_exception(self, exception, traceback_data, handled=True):
+    def set_exception(
+            self,
+            exception,
+            traceback_data,
+            handled=True,
+            from_logs=False
+    ):
         """
         Sets exception data on event.
         :param exception: Exception object
         :param traceback_data: traceback string
         :param handled: False if the exception was raised from the wrapped
             function
+        :param from_logs: True if the exception was captured from logging
         """
 
         self.error_code = ErrorCode.EXCEPTION
@@ -111,3 +118,5 @@ class BaseEvent(object):
         self.exception['traceback'] = traceback_data
         self.exception['time'] = time.time()
         self.exception.setdefault('additional_data', {})['handled'] = handled
+        if from_logs:
+            self.exception['additional_data']['from_logs'] = True

--- a/epsagon/events/azure.py
+++ b/epsagon/events/azure.py
@@ -80,14 +80,21 @@ class AzureEvent(BaseEvent):
         """
         self.RESPONSE_TO_FUNC.get(self.resource['operation'], empty_func)()
 
-    def set_exception(self, exception, traceback_data, handled=True):
+    def set_exception(
+            self,
+            exception,
+            traceback_data,
+            handled=True,
+            from_logs=False
+    ):
         """
         see {Event.set_exception}
         """
         super(AzureEvent, self).set_exception(
             exception,
             traceback_data,
-            handled=handled
+            handled=handled,
+            from_logs=from_logs
         )
 
         # Specific handling for azure errors

--- a/epsagon/events/botocore.py
+++ b/epsagon/events/botocore.py
@@ -79,14 +79,21 @@ class BotocoreEvent(BaseEvent):
         if exception is not None:
             self.set_exception(exception, traceback.format_exc())
 
-    def set_exception(self, exception, traceback_data, handled=True):
+    def set_exception(
+            self,
+            exception,
+            traceback_data,
+            handled=True,
+            from_logs=False
+    ):
         """
         see {Event.set_exception}
         """
         super(BotocoreEvent, self).set_exception(
             exception,
             traceback_data,
-            handled=handled
+            handled=handled,
+            from_logs=from_logs
         )
 
         # Specific handling for botocore errors

--- a/epsagon/modules/logging.py
+++ b/epsagon/modules/logging.py
@@ -35,7 +35,7 @@ def _wrapper(wrapped, _instance, args, kwargs):
     if not os.getenv('EPSAGON_DISABLE_LOGGING_ERRORS', '').upper() == 'TRUE':
         try:
             message = args[0] % args[1:]
-            trace_factory.set_error(message)
+            trace_factory.set_error(message, from_logs=True)
         except Exception:  # pylint: disable=broad-except
             print_debug('Could not capture exception from log: {}'.format(
                 args

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -443,14 +443,19 @@ class TraceFactory(object):
             return self.get_trace().get_log_id()
         return None
 
-    def set_error(self, exception, traceback_data=None):
+    def set_error(self, exception, traceback_data=None, from_logs=False):
         """
         Set an error for the current thread's trace.
         :param exception: The exception
         :param traceback_data: The traceback data.
+        :param from_logs: True if the exception was captured from logging
         """
         if self.get_trace():
-            self.get_trace().set_error(exception, traceback_data)
+            self.get_trace().set_error(
+                exception,
+                traceback_data,
+                from_logs=from_logs
+            )
 
     def send_traces(self, trace=None):
         """
@@ -811,11 +816,12 @@ class Trace(object):
 
         return None
 
-    def set_error(self, exception, traceback_data=None):
+    def set_error(self, exception, traceback_data=None, from_logs=False):
         """
         Sets the error value of the runner
         :param exception: Exception object or String to set.
         :param traceback_data: traceback string
+        :param from_logs: True if the exception was captured from logging
         """
         if not self.runner:
             return
@@ -834,7 +840,12 @@ class Trace(object):
         # Convert exception string to Exception type
         if isinstance(exception, str):
             exception = Exception(exception)
-        self.runner.set_exception(exception, traceback_data)
+
+        self.runner.set_exception(
+            exception,
+            traceback_data,
+            from_logs=from_logs
+        )
 
     def update_runner_with_labels(self):
         """

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -17,7 +17,7 @@ import json
 import urllib3.exceptions
 
 from epsagon.event import BaseEvent
-from epsagon.common import EpsagonWarning, ErrorCode, EpsagonException
+from epsagon.common import EpsagonWarning, ErrorCode
 from epsagon.trace_encoder import TraceEncoder
 from epsagon.trace_transports import NoneTransport, HTTPTransport, LogTransport
 from .constants import (
@@ -831,9 +831,9 @@ class Trace(object):
                 traceback_data = ''.join(
                     traceback.format_list(traceback.extract_stack())
                 )
-        # Convert exception string to EpsagonException type
+        # Convert exception string to Exception type
         if isinstance(exception, str):
-            exception = EpsagonException(exception)
+            exception = Exception(exception)
         self.runner.set_exception(exception, traceback_data)
 
     def update_runner_with_labels(self):

--- a/tests/modules/test_logging.py
+++ b/tests/modules/test_logging.py
@@ -21,7 +21,8 @@ def test_logging_exception_capture(trace_transport):
     assert wrapped_function('a', 'b') == retval
 
     exception = trace_transport.last_trace.events[0].exception
-    assert exception['type'] == 'EpsagonException'
+    assert exception['type'] == 'Exception'
+    assert exception['additional_data']['from_logs'] is True
     assert exception['message'] == 'test'
 
 
@@ -36,5 +37,6 @@ def test_logging_exception_capture_with_args(trace_transport):
     assert wrapped_function('a', 'b') == retval
 
     exception = trace_transport.last_trace.events[0].exception
-    assert exception['type'] == 'EpsagonException'
+    assert exception['type'] == 'Exception'
+    assert exception['additional_data']['from_logs'] is True
     assert exception['message'] == 'test test test'

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -24,7 +24,7 @@ from epsagon.trace import (
     MAX_METADATA_FIELD_SIZE_LIMIT
 )
 from epsagon.utils import get_tc_url
-from epsagon.common import ErrorCode, EpsagonException
+from epsagon.common import ErrorCode
 from epsagon.trace_transports import HTTPTransport
 from .conftest import init_epsagon
 
@@ -108,7 +108,7 @@ class RunnerEventMock(EventMock):
     def set_timeout(self):
         pass
 
-    def set_exception(self, exception, traceback_data):
+    def set_exception(self, exception, traceback_data, handled=True, from_logs=False):
         self.error_code = ErrorCode.EXCEPTION
         self.exception['type'] = type(exception).__name__
         self.exception['message'] = str(exception)
@@ -411,7 +411,7 @@ def test_set_error_string():
 
     assert trace.to_dict()['events'][0]['exception']['message'] == msg
     assert trace.to_dict()['events'][0]['exception']['type'] == (
-        EpsagonException.__name__
+        Exception.__name__
     )
 
 


### PR DESCRIPTION
Currently `EpsagonException` is being used from exceptions that we capture from logs (logging.exception). The name is confusing since it implies that Epsagon had an error. To make it as simple as possible, we'll use the base exception, and add another param `from_logs`

currently:
![image](https://user-images.githubusercontent.com/24767098/93705481-6c264d80-fb26-11ea-9ece-500651a9d846.png)
