### PR TITLE
fix(logging.py): fix add trace id to logs flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,8 +453,8 @@ Advanced options can be configured as a parameter to the init() method or as env
 |disable_timeout_send    |EPSAGON_DISABLE_ON_TIMEOUT     |Boolean|`False`      |Disable timeout detection in Lambda functions                                      |
 |split_on_send           |EPSAGON_SPLIT_ON_SEND          |Boolean|`False`      |Split the trace into multiple chunks to support large traces                       |
 |propagate_lambda_id     |EPSAGON_PROPAGATE_LAMBDA_ID    |Boolean|`False`      |Insert Lambda request ID into the response payload                                 |
-|logging_tracing_enabled |EPSAGON_LOGGING_TRACING_ENABLED|Boolean|`True`      |Add Epsagon Log Id to all `logging` messages                            |
-|step_dict_output_path |EPSAGON_STEPS_OUTPUT_PATH|List|`None`      |Path in the result dict to append the Epsagon steps data  |
+|step_dict_output_path   |EPSAGON_STEPS_OUTPUT_PATH|List|`None`      |Path in the result dict to append the Epsagon steps data                                     |
+|-                       |EPSAGON_LOGGING_TRACING_ENABLED|Boolean|`True`      |Add Epsagon Log Id to all `logging` messages                                        |
 |-                       |EPSAGON_HTTP_ERR_CODE          |Integer|`500`        |The minimum number of an HTTP response status code to treat as an error            |
 |-                       |EPSAGON_SEND_TIMEOUT_SEC       |Float  |`1.0`        |The timeout duration in seconds to send the traces to the trace collector          |
 |-                       |EPSAGON_DISABLE_LOGGING_ERRORS |Boolean|`False`      |Disable the automatic capture of error messages into `logging`                     |

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -100,7 +100,7 @@ class TraceFactory(object):
         self.split_on_send = False
         self.disabled = False
         self.propagate_lambda_id = False
-        self.logging_tracing_enabled = False
+        self.logging_tracing_enabled = True
         self.step_dict_output_path = None
         self.sample_rate = DEFAULT_SAMPLE_RATE
 
@@ -433,7 +433,12 @@ class TraceFactory(object):
         """
         Get the value of the logging_tracing_enabled flag
         """
-        return self.logging_tracing_enabled
+        if os.getenv('EPSAGON_LOGGING_TRACING_ENABLED'):
+            return (
+                os.getenv('EPSAGON_LOGGING_TRACING_ENABLED') or ''
+            ).upper() == 'TRUE'
+
+        return False
 
     def get_log_id(self):
         """

--- a/epsagon/utils.py
+++ b/epsagon/utils.py
@@ -110,7 +110,6 @@ def init(
     ignored_endpoints=None,
     split_on_send=False,
     propagate_lambda_id=False,
-    logging_tracing_enabled=True,
     step_dict_output_path=None,
     sample_rate=DEFAULT_SAMPLE_RATE,
 ):
@@ -134,7 +133,6 @@ def init(
     :param ignored_endpoints: List of ignored endpoints for web frameworks.
     :param split_on_send: Split the trace on send flag
     :param propagate_lambda_id: Inject identifiers via return value flag
-    :param logging_tracing_enabled: Add an epsagon log id to logging calls
     :param step_dict_output_path:
         Path in the result dict to append the Epsagon steps data
     :param sample_rate: A number between 0 and 1, represents the probability
@@ -175,6 +173,7 @@ def init(
         metadata_only = (os.getenv('EPSAGON_METADATA') or '').upper() == 'TRUE'
 
     # If EPSAGON_LOGGING_TRACING_ENABLED exists as an env var - use it
+    logging_tracing_enabled = False
     if os.getenv('EPSAGON_LOGGING_TRACING_ENABLED'):
         logging_tracing_enabled = (
             os.getenv('EPSAGON_LOGGING_TRACING_ENABLED') or ''


### PR DESCRIPTION
Fixing the flag set for trace factory.
What happened is that logging.py patch was called on import epsagon, so when we checked if logging_enabled we always got FALSE - no matter what was the given flag value.
