### PR TITLE
Fix memory leaks ep 5511

### DIFF
--- a/epsagon/http_filters.py
+++ b/epsagon/http_filters.py
@@ -76,7 +76,10 @@ def is_payload_collection_blacklisted(url):
     :return:  True if URL is blacklisted, else False
     """
     url = urllib.parse.urlparse(url).netloc
-    trace_blacklist_urls = trace_factory.get_trace().url_patterns_to_ignore
+    if trace_factory.get_trace():
+        trace_blacklist_urls = trace_factory.get_trace().url_patterns_to_ignore
+    else:
+        trace_blacklist_urls = tuple()
     return any(blacklist_url in url for blacklist_url in trace_blacklist_urls)
 
 

--- a/epsagon/runners/python_function.py
+++ b/epsagon/runners/python_function.py
@@ -64,7 +64,7 @@ class PythonRunner(BaseEvent):
         Add a field to metadata with value `data` and name `name`,
             only if it is JSON serializable
         """
-        if epsagon.trace.trace_factory.get_trace().metadata_only:
+        if epsagon.trace.trace_factory.get_or_create_trace().metadata_only:
             return
 
         try:

--- a/epsagon/runners/python_function.py
+++ b/epsagon/runners/python_function.py
@@ -64,7 +64,8 @@ class PythonRunner(BaseEvent):
         Add a field to metadata with value `data` and name `name`,
             only if it is JSON serializable
         """
-        if epsagon.trace.trace_factory.get_or_create_trace().metadata_only:
+        trace = epsagon.trace.trace_factory.get_trace()
+        if not trace or trace.metadata_only:
             return
 
         try:

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -276,7 +276,7 @@ class TraceFactory(object):
             if not task:
                 return self._get_thread_trace()
         except RuntimeError:
-            return self._get_thread_trace(should_create)
+            return self._get_thread_trace(should_create=should_create)
 
         trace = getattr(task, EPSAGON_MARKER, None)
         if not trace and should_create:

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -278,7 +278,7 @@ class TraceFactory(object):
 
     def _get_tracer_async_mode(self, should_create):
         """
-        Get or create trace assuming async tracer.
+        Get trace assuming async tracer.
         :return: The trace.
         """
         task = type(self)._get_current_task()

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -295,7 +295,7 @@ class TraceFactory(object):
         :return: The trace.
         """
         if self.use_async_tracer:
-            return self._get_tracer_async_mode(should_create)
+            return self._get_tracer_async_mode(should_create=should_create)
 
         unique_id = self.get_thread_local_unique_id(unique_id)
         if unique_id:

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -346,7 +346,8 @@ class TraceFactory(object):
                     self.singleton_trace = self._create_new_trace()
                 return self.singleton_trace
 
-            # If multiple threads are used, then create a new trace for each thread
+            # If multiple threads are used, then create a
+            # new trace for each thread
             return self._get_thread_trace(should_create=should_create)
 
     @property

--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -274,7 +274,7 @@ class TraceFactory(object):
         try:
             task = asyncio.Task.current_task()
             if not task:
-                return self._get_thread_trace()
+                return self._get_thread_trace(should_create=should_create)
         except RuntimeError:
             return self._get_thread_trace(should_create=should_create)
 

--- a/epsagon/wrappers/flask.py
+++ b/epsagon/wrappers/flask.py
@@ -125,10 +125,8 @@ class FlaskWrapper(object):
         :param exception: Exception (or None).
         :return: None.
         """
-
         if self.ignored_request:
             return
-
         trace = epsagon.trace.trace_factory.get_or_create_trace()
         if exception and trace.runner:
             traceback_data = get_traceback_data_from_exception(exception)

--- a/tests/events/test_eventbridge.py
+++ b/tests/events/test_eventbridge.py
@@ -19,7 +19,11 @@ fake_event_bus_name_missing = {
 
 def setup_function(func):
     trace_factory.use_single_trace = True
+    trace_factory.get_or_create_trace()
 
+
+def teardown_function(func):
+    trace_factory.singleton_trace = None
 
 def _get_active_trace():
     return trace_factory.active_trace

--- a/tests/wrappers/common.py
+++ b/tests/wrappers/common.py
@@ -2,6 +2,8 @@
 Common tests helpers
 """
 import mock
+import requests
+from threading import Thread
 
 
 def get_tracer_patch_kwargs():
@@ -15,3 +17,25 @@ def get_tracer_patch_kwargs():
         'add_exception': mock.MagicMock(),
         'set_runner': mock.MagicMock()
     }
+
+
+def _send_get_request(target_url, results):
+    """
+    Sends a get requests to a given target URL string
+    :return: the given target url
+    """
+    requests.get(target_url)
+    results.append(target_url)
+
+
+def multiple_threads_handler():
+    threads = []
+    results = []
+    threads_count = 3
+    for i in range(threads_count):
+        thread = Thread(target = _send_get_request, args = ("http://google.com", results))
+        thread.start()
+        threads.append(thread)
+    for thread in threads:
+        thread.join()
+    assert len(results) == threads_count

--- a/tests/wrappers/common.py
+++ b/tests/wrappers/common.py
@@ -28,10 +28,14 @@ def _send_get_request(target_url, results):
     results.append(target_url)
 
 
-def multiple_threads_handler():
+def multiple_threads_handler(threads_count=3):
+    """
+    Invokes `threads_count` new threads, each performs an HTTP get request.
+    Waits for all threads and validates a result has been returned from each
+    thread.
+    """
     threads = []
     results = []
-    threads_count = 3
     for i in range(threads_count):
         thread = Thread(target = _send_get_request, args = ("http://google.com", results))
         thread.start()

--- a/tests/wrappers/test_flask_wrapper.py
+++ b/tests/wrappers/test_flask_wrapper.py
@@ -90,11 +90,12 @@ def test_flask_wrapper_after_request(runner_mock, _, client):
 
 @mock.patch('warnings.warn')
 @mock.patch('epsagon.trace.trace_factory.get_or_create_trace')
-def test_flask_wrapper_teardown_request(trace_mock, _, client):
+@mock.patch('epsagon.trace.trace_factory.get_trace')
+def test_flask_wrapper_teardown_request(get_trace_mock, create_trace_mock, _, client):
     """Test tracer gets new event and send it on new request."""
     client.get('/')
-    trace_mock().set_runner.assert_called_once()
-    trace_mock().send_traces.assert_called_once()
+    create_trace_mock().set_runner.assert_called_once()
+    get_trace_mock().send_traces.assert_called_once()
 
 
 @mock.patch('warnings.warn')

--- a/tests/wrappers/test_flask_wrapper.py
+++ b/tests/wrappers/test_flask_wrapper.py
@@ -177,4 +177,5 @@ def test_flask_wrapper_route_multiple_threads(trace_transport, client):
     role = 'multiple_threads'
     result = client.get('/{}'.format(role))
     validate_response(role, result, trace_transport)
+    # validating no `zombie` traces exist
     assert not trace_factory.traces


### PR DESCRIPTION
- no traces will be created if there is no runner. (splitting get_trace and get_or_create_trace)
- catching failure at send traces , avoiding "zombie" traces
- async mode: cleaning tracer from task after its being sent