### PR TITLE
fix(tornado.py): fix mishandling of 404s

### DIFF
--- a/epsagon/events/redis.py
+++ b/epsagon/events/redis.py
@@ -8,6 +8,8 @@ import traceback
 
 from ..event import BaseEvent
 from ..trace import trace_factory
+from ..utils import add_data_if_needed
+
 
 MAX_VALUE_SIZE = 1024
 MAX_CMD_PIPELINE = 10
@@ -109,6 +111,14 @@ class RedisSingleExecutionEvent(BaseRedisEvent):
         operation, key = _parse_redis_cmd(args)
         self.resource['operation'] = operation
         self.resource['metadata']['Redis Key'] = key
+
+        if response:
+            print('***'*100)
+            add_data_if_needed(
+                self.resource['metadata'],
+                'redis.response',
+                response
+            )
 
 
 class RedisMultiExecutionEvent(BaseRedisEvent):

--- a/epsagon/events/redis.py
+++ b/epsagon/events/redis.py
@@ -113,7 +113,6 @@ class RedisSingleExecutionEvent(BaseRedisEvent):
         self.resource['metadata']['Redis Key'] = key
 
         if response:
-            print('***'*100)
             add_data_if_needed(
                 self.resource['metadata'],
                 'redis.response',

--- a/epsagon/events/urllib3.py
+++ b/epsagon/events/urllib3.py
@@ -113,9 +113,7 @@ class Urllib3Event(BaseEvent):
                 'response_headers',
                 headers
             )
-            response_body = getattr(response, 'data', None)
-            if not response_body and getattr(response, 'peek', None):
-                response_body = response.peek()
+            response_body = response.peek()
             if isinstance(response_body, bytes):
                 try:
                     response_body = response_body.decode('utf-8')

--- a/epsagon/events/urllib3.py
+++ b/epsagon/events/urllib3.py
@@ -113,16 +113,20 @@ class Urllib3Event(BaseEvent):
                 'response_headers',
                 headers
             )
-            response_body = response.peek()
+            response_body = getattr(response, 'data', None)
+            if not response_body and getattr(response, 'peek', None):
+                response_body = response.peek()
             if isinstance(response_body, bytes):
                 try:
                     response_body = response_body.decode('utf-8')
                 except UnicodeDecodeError:
                     response_body = str(response_body)
-            add_data_if_needed(
-                self.resource['metadata'],
-                'response_body',
-                response_body)
+            if response_body:
+                add_data_if_needed(
+                    self.resource['metadata'],
+                    'response_body',
+                    response_body
+                )
 
         # Detect errors based on status code
         if response.status >= HTTP_ERR_CODE:

--- a/epsagon/modules/logging.py
+++ b/epsagon/modules/logging.py
@@ -71,7 +71,6 @@ def _epsagon_trace_id_wrapper(msg_index, wrapped, _instance, args, kwargs):
     :param kwargs: wrapt's kwargs
     :return: None
     """
-    # import ipdb;ipdb.set_trace()
     trace_log_id = trace_factory.get_log_id()
 
     if not trace_log_id:

--- a/epsagon/modules/logging.py
+++ b/epsagon/modules/logging.py
@@ -11,7 +11,7 @@ from functools import partial
 import wrapt
 
 from ..trace import trace_factory
-from ..utils import print_debug
+from ..utils import print_debug, get_trace_log_config
 
 LOGGING_FUNCTIONS = (
     'info',
@@ -71,6 +71,7 @@ def _epsagon_trace_id_wrapper(msg_index, wrapped, _instance, args, kwargs):
     :param kwargs: wrapt's kwargs
     :return: None
     """
+    # import ipdb;ipdb.set_trace()
     trace_log_id = trace_factory.get_log_id()
 
     if not trace_log_id:
@@ -99,7 +100,7 @@ def patch():
     wrapt.wrap_function_wrapper('logging', 'Logger.exception', _wrapper)
 
     # Instrument logging with Epsagon trace ID
-    if trace_factory.is_logging_tracing_enabled():
+    if get_trace_log_config():
         wrapt.wrap_function_wrapper(
             'logging',
             'Logger.log',

--- a/epsagon/modules/redis.py
+++ b/epsagon/modules/redis.py
@@ -44,6 +44,12 @@ def patch():
         'Redis.execute_command',
         _single_wrapper
     )
+    # Version < 3.0
+    wrapt.wrap_function_wrapper(
+        'redis',
+        'StrictRedis.execute_command',
+        _single_wrapper
+    )
     wrapt.wrap_function_wrapper(
         'redis.client',
         'Pipeline.immediate_execute_command',

--- a/epsagon/modules/tornado.py
+++ b/epsagon/modules/tornado.py
@@ -92,7 +92,8 @@ class TornadoWrapper(object):
             tornado_runner = cls.RUNNERS.pop(unique_id)
 
             # Ignoring 404s
-            if getattr(instance, '._status_code', None) == 404:
+            if getattr(instance, '_status_code', None) == 404:
+                print_debug('Ignoring 404 Tornado request')
                 return res
 
             trace = epsagon.trace.trace_factory.switch_active_trace(

--- a/epsagon/modules/tornado.py
+++ b/epsagon/modules/tornado.py
@@ -11,7 +11,7 @@ import wrapt
 import epsagon.trace
 from epsagon.runners.tornado import TornadoRunner
 from epsagon.http_filters import ignore_request, is_ignored_endpoint
-from epsagon.utils import collect_container_metadata
+from epsagon.utils import collect_container_metadata, print_debug
 
 TORNADO_TRACE_ID = 'epsagon_tornado_trace_key'
 
@@ -31,6 +31,7 @@ class TornadoWrapper(object):
         :param args: wrapt's args
         :param kwargs: wrapt's kwargs
         """
+        print_debug('before_request Tornado request')
         try:
             ignored = ignore_request('', instance.request.path)
             if not ignored and not is_ignored_endpoint(instance.request.path):
@@ -48,6 +49,7 @@ class TornadoWrapper(object):
                 )
 
                 trace.set_runner(cls.RUNNERS[unique_id])
+                print_debug('Created Tornado Runner')
 
                 # Collect metadata in case this is a container.
                 collect_container_metadata(
@@ -69,9 +71,18 @@ class TornadoWrapper(object):
         :param args: wrapt's args
         :param kwargs: wrapt's kwargs
         """
-        response_body = getattr(instance, '_write_buffer', None)
-        if response_body and isinstance(response_body, list):
-            response_body = b''.join(response_body)
+        print_debug('after_request Tornado request')
+        response_body = None
+        try:
+            response_body = getattr(instance, '_write_buffer', None)
+            if response_body and isinstance(response_body, list):
+                response_body = b''.join(response_body)
+        except Exception as instrumentation_exception:  # pylint: disable=W0703
+            epsagon.trace.trace_factory.add_exception(
+                instrumentation_exception,
+                traceback.format_exc()
+            )
+
         res = wrapped(*args, **kwargs)
         try:
             unique_id = getattr(instance, TORNADO_TRACE_ID, None)
@@ -79,6 +90,10 @@ class TornadoWrapper(object):
                 return res
 
             tornado_runner = cls.RUNNERS.pop(unique_id)
+
+            # Ignoring 404s
+            if getattr(instance, '._status_code', None) == 404:
+                return res
 
             trace = epsagon.trace.trace_factory.switch_active_trace(
                 unique_id
@@ -111,6 +126,7 @@ class TornadoWrapper(object):
         :param args: wrapt's args
         :param kwargs: wrapt's kwargs
         """
+        print_debug('collect_exception Tornado request')
         try:
             unique_id = getattr(instance, TORNADO_TRACE_ID, None)
 

--- a/epsagon/runners/aiohttp.py
+++ b/epsagon/runners/aiohttp.py
@@ -39,7 +39,7 @@ class AiohttpRunner(BaseEvent):
             'Base URL': request.url.host,
             'Path': request.url.path,
             'User Agent': request.headers.get('User-Agent', 'N/A'),
-            'Endpoint': handler.__name__,
+            'Endpoint': getattr(handler, '__name__', ''),
         })
 
         if request.query_string:

--- a/epsagon/runners/tornado.py
+++ b/epsagon/runners/tornado.py
@@ -96,10 +96,16 @@ class TornadoRunner(BaseEvent):
         )
 
         if response_body:
+            body = response_body
+            if isinstance(body, list):
+                body = body[0]
+            if isinstance(body, bytes):
+                body = body.decode('utf-8')
+
             add_data_if_needed(
                 self.resource['metadata'],
                 'Response Body',
-                str(response_body)[:MAX_PAYLOAD_BYTES]
+                str(body)[:MAX_PAYLOAD_BYTES]
             )
 
         self.resource['metadata']['status_code'] = response._status_code

--- a/epsagon/runners/tornado.py
+++ b/epsagon/runners/tornado.py
@@ -6,7 +6,7 @@ Runner for a Tornado Python framework
 from __future__ import absolute_import
 import uuid
 from ..event import BaseEvent
-from ..utils import add_data_if_needed
+from ..utils import add_data_if_needed, print_debug
 from ..constants import EPSAGON_HEADER_TITLE
 
 MAX_PAYLOAD_BYTES = 2000
@@ -68,6 +68,19 @@ class TornadoRunner(BaseEvent):
                 'Request Headers',
                 request_headers
             )
+
+        try:
+            if request.body:
+                body = request.body
+                if isinstance(body, bytes):
+                    body = body.decode('utf-8')
+                add_data_if_needed(
+                    self.resource['metadata'],
+                    'Request Data',
+                    body
+                )
+        except Exception as exception:  # pylint: disable=broad-except
+            print_debug('Could not extract body: {}'.format(exception))
 
     def update_response(self, response, response_body=None):
         """

--- a/epsagon/utils.py
+++ b/epsagon/utils.py
@@ -95,6 +95,23 @@ def get_tc_url(use_ssl):
     return TRACE_COLLECTOR_URL.format(protocol=protocol, region=REGION)
 
 
+def get_trace_log_config():
+    # Default is True
+    logging_tracing_enabled = True
+
+    # If EPSAGON_LOGGING_TRACING_ENABLED exists as an env var - use it
+    if os.getenv('EPSAGON_LOGGING_TRACING_ENABLED'):
+        logging_tracing_enabled = (
+            os.getenv('EPSAGON_LOGGING_TRACING_ENABLED') or ''
+        ).upper() == 'TRUE'
+
+    # In case we're running on AWS Lambda, logging correlation is disabled
+    if is_lambda_env():
+        logging_tracing_enabled = False
+
+    return logging_tracing_enabled
+
+
 def init(
     token='',
     app_name='Application',
@@ -174,15 +191,7 @@ def init(
     if os.getenv('EPSAGON_METADATA'):
         metadata_only = (os.getenv('EPSAGON_METADATA') or '').upper() == 'TRUE'
 
-    # If EPSAGON_LOGGING_TRACING_ENABLED exists as an env var - use it
-    if os.getenv('EPSAGON_LOGGING_TRACING_ENABLED'):
-        logging_tracing_enabled = (
-            os.getenv('EPSAGON_LOGGING_TRACING_ENABLED') or ''
-        ).upper() == 'TRUE'
-
-    # In case we're running on AWS Lambda, logging correlation is disabled
-    if is_lambda_env():
-        logging_tracing_enabled = False
+    logging_tracing_enabled = get_trace_log_config()
 
     if os.getenv('EPSAGON_SAMPLE_RATE'):
         sample_rate = float(os.getenv('EPSAGON_SAMPLE_RATE'))

--- a/epsagon/utils.py
+++ b/epsagon/utils.py
@@ -97,20 +97,15 @@ def get_tc_url(use_ssl):
 
 def get_trace_log_config():
     """Returns the trace log correlation configuration"""
-    # Default is True
-    logging_tracing_enabled = True
+    # In case we're running on AWS Lambda, logging correlation is disabled
+    if is_lambda_env():
+        return False
 
     # If EPSAGON_LOGGING_TRACING_ENABLED exists as an env var - use it
     if os.getenv('EPSAGON_LOGGING_TRACING_ENABLED'):
-        logging_tracing_enabled = (
-            os.getenv('EPSAGON_LOGGING_TRACING_ENABLED') or ''
-        ).upper() == 'TRUE'
+        return os.getenv('EPSAGON_LOGGING_TRACING_ENABLED').upper() == 'TRUE'
 
-    # In case we're running on AWS Lambda, logging correlation is disabled
-    if is_lambda_env():
-        logging_tracing_enabled = False
-
-    return logging_tracing_enabled
+    return True
 
 
 def init(

--- a/epsagon/utils.py
+++ b/epsagon/utils.py
@@ -96,6 +96,7 @@ def get_tc_url(use_ssl):
 
 
 def get_trace_log_config():
+    """Returns the trace log correlation configuration"""
     # Default is True
     logging_tracing_enabled = True
 

--- a/epsagon/wrappers/aiohttp.py
+++ b/epsagon/wrappers/aiohttp.py
@@ -48,6 +48,11 @@ async def AiohttpMiddleware(request, handler):
     try:
         response = await handler(request)
     except Exception as exception:  # pylint: disable=W0703
+        # Ignoring 404s
+        if type(exception).__name__ == 'HTTPNotFound':
+            epsagon.trace.trace_factory.pop_trace(trace)
+            raise
+
         raised_err = exception
         traceback_data = get_traceback_data_from_exception(exception)
         trace.runner.set_exception(exception, traceback_data)

--- a/tests/wrappers/test_aiohttp_wrapper.py
+++ b/tests/wrappers/test_aiohttp_wrapper.py
@@ -53,3 +53,15 @@ async def test_aiohttp_exception(_, trace_transport, aiohttp_client):
     assert runner.error_code == ErrorCode.EXCEPTION
     assert runner.exception['type'] == 'CustomAioHttpException'
     assert runner.exception['message'] == 'test'
+
+
+@asynctest.patch('epsagon.trace.trace_factory.use_async_tracer')
+async def test_aiohttp_no_endpoint(_, trace_transport, aiohttp_client):
+    """Test when no route exists (404)."""
+    client = await aiohttp_client(create_app)
+    response = await client.get('/not/exists')
+    assert response.status == 404
+    # Trace not sent
+    trace_transport.send.assert_not_called()
+    # Trace removed
+    assert trace_transport.last_trace is None


### PR DESCRIPTION
In addition:

1. capturing redis response
2. support older redis versions
3. Fixing mishandling of 404 in aiohttp
4. fixing log-correlation that was always handled as False (since trace_factory was not initialized)
5. adding some debug prints to Tornado