### PR TITLE
fix(celery.py): fix celery trace creation

### DIFF
--- a/epsagon/events/celery.py
+++ b/epsagon/events/celery.py
@@ -160,7 +160,7 @@ def wrap_prerun(*args, **kwargs):
     """
     event_key = get_event_key(*args, **kwargs)
     if event_key:
-        trace_factory.prepare()
+        trace_factory.get_or_create_trace(unique_id=event_key)
         runner = CeleryRunner(*args, **kwargs)
         ACTIVE_EVENTS[event_key] = runner
         trace_factory.set_runner(runner)

--- a/epsagon/runners/celery.py
+++ b/epsagon/runners/celery.py
@@ -45,7 +45,7 @@ class CeleryRunner(BaseEvent):
         self.resource['metadata'].update({
             'id': task_id,
             'state': state,
-            'hostname': app_conn.hostname,
+            'hostname': app_conn.hostname or 'localhost',
             'virtual_host': app_conn.virtual_host,
             'driver': app_conn.transport.driver_type,
         })


### PR DESCRIPTION
since some version, `prepare` does not create a trace anymore, causing celery to stop working. So we're changing it to `get_or_create_trace`

fixes: https://github.com/epsagon/epsagon-python/issues/345