### PR TITLE
Revert "fix(urllib3.py): urrlib3 event collection failed"

### DIFF
--- a/epsagon/events/urllib3.py
+++ b/epsagon/events/urllib3.py
@@ -113,7 +113,6 @@ class Urllib3Event(BaseEvent):
                 'response_headers',
                 headers
             )
-            # Backward compatibility for urllib3<1.26.x
             response_body = (
                 response.peek()
                 if getattr(response, 'peek', None)


### PR DESCRIPTION
Reverts epsagon/epsagon-python#352