### PR TITLE
fix(utils.py): show original import error

### DIFF
--- a/epsagon/utils.py
+++ b/epsagon/utils.py
@@ -280,8 +280,8 @@ def import_original_module():
 
     try:
         return __import__(module_path), module_path, handler_name
-    except ImportError:
-        raise ImportError('Failed to import module: {}'.format(module_path))
+    except ImportError as ex:
+        raise ImportError('Failed to import module: {}, Error: {}'.format(module_path, ex))
 
 
 def collect_container_metadata(metadata):

--- a/epsagon/utils.py
+++ b/epsagon/utils.py
@@ -281,7 +281,9 @@ def import_original_module():
     try:
         return __import__(module_path), module_path, handler_name
     except ImportError as ex:
-        raise ImportError('Failed to import module: {}, Error: {}'.format(module_path, ex))
+        raise ImportError(
+            'Failed to import module: {}, Error: {}'.format(module_path, ex)
+        )
 
 
 def collect_container_metadata(metadata):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ requests
 sqlalchemy==1.3.23
 psycopg2
 aiohttp; python_version >= '3.5'
-fastapi; python_version >= '3.5'
+fastapi==0.65.2; python_version >= '3.5'
 pytest-asyncio; python_version >= '3.5'
 pytest-aiohttp; python_version >= '3.5'
 httpx; python_version >= '3.5'


### PR DESCRIPTION
Instead of getting this:
`Unable to import module 'epsagon': Failed to import module: index`
Get this:
`Unable to import module 'epsagon': Failed to import module: lambda_function, Error: No module named 'mod'`

(this will expose the real import error to the user)