### PR TITLE
feat(aws_lambda): do not trace warmup events from serverless-plugin-warmup plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ Advanced options can be configured as a parameter to the init() method or as env
 |-                       |DISABLE_EPSAGON                |Boolean|`False`      |A flag to completely disable Epsagon (can be used for tests or locally)            |
 |-                       |DISABLE_EPSAGON_PATCH          |Boolean|`False`      |Disable the library patching (instrumentation)                                     |
 |-                       |EPSAGON_LAMBDA_TIMEOUT_THRESHOLD_MS          |Integer|`200`      |The threshold in millieseconds to send the trace before a Lambda timeout occurs                                     |
+|-                       |EPSAGON_PAYLOADS_TO_IGNORE     |List   |-            |Array of dictionaries to not instrument. Example: `'{"source": "serverless-plugin-warmup"}'` |
 
 
 ## Getting Help

--- a/epsagon/wrappers/aws_lambda.py
+++ b/epsagon/wrappers/aws_lambda.py
@@ -60,6 +60,10 @@ def lambda_wrapper(func):
             # parameters / sends kwargs. In such case we ignore this trace.
             return func(*args, **kwargs)
 
+        if isinstance(event, dict) and event.get("source") == "serverless-plugin-warmup":
+            # Do not trace serverless-plugin-warmup invocations
+            return func(*args, **kwargs)
+
         if os.environ.get(
             'AWS_LAMBDA_INITIALIZATION_TYPE'
         ) == 'provisioned-concurrency':

--- a/epsagon/wrappers/aws_lambda.py
+++ b/epsagon/wrappers/aws_lambda.py
@@ -3,6 +3,8 @@ Wrapper for AWS Lambda.
 """
 
 from __future__ import absolute_import
+
+import json
 import os
 import traceback
 import time
@@ -36,6 +38,15 @@ def _add_status_code(runner, return_value):
             runner.resource['metadata']['status_code'] = status_code
 
 
+def _get_ignored_payloads():
+    """Return a list of payload dictionaries to ignore, if any"""
+    ignored_payloads = os.environ.get("EPSAGON_PAYLOADS_TO_IGNORE")
+    if ignored_payloads:
+        return [json.loads(payload) for payload in ignored_payloads.split(",")]
+
+    return []
+
+
 # pylint: disable=too-many-statements
 def lambda_wrapper(func):
     """Epsagon's Lambda wrapper."""
@@ -60,9 +71,10 @@ def lambda_wrapper(func):
             # parameters / sends kwargs. In such case we ignore this trace.
             return func(*args, **kwargs)
 
-        if isinstance(event, dict) and event.get("source") == "serverless-plugin-warmup":
-            # Do not trace serverless-plugin-warmup invocations
-            return func(*args, **kwargs)
+        if isinstance(event, dict):
+            ignored_payloads = _get_ignored_payloads()
+            if ignored_payloads and event in ignored_payloads:
+                return func(*args, **kwargs)
 
         if os.environ.get(
             'AWS_LAMBDA_INITIALIZATION_TYPE'


### PR DESCRIPTION
👋 We started using Epsagon and are looking for a way to use `serverless-plugin-epsagon` in combination with `serverless-plugin-warmup`.

This however would work perfectly for us, it enables us to let the plugin do the heavy lifting which would work for most of our projects, and still use the warmup plugin.

Other ideas, of which the fist has my preference:
1. Add a key like `ignoredPayloads` to https://github.com/epsagon/serverless-plugin-epsagon which could take a dict like `{"source": "serverless-plugin-warmup"}` or list of dicts. If enabled, use that/those patterns in https://github.com/epsagon/epsagon-python . One upside would be that it removes hardcoding a payload currently generated by the warmup plugin and could support other use cases.
2. Allow people to bring their own wrappers for your wrapper. Not sure if I'm a fan of this but it's something that I looked for as a way to solve my problem.

I've raised https://github.com/epsagon/serverless-plugin-epsagon/issues/106 suggesting option one to see if there is an appetite for it.