### PR TITLE
Resetting `trace_mock.call_count` to initial state 0

### DIFF
--- a/tests/wrappers/test_python_function.py
+++ b/tests/wrappers/test_python_function.py
@@ -69,6 +69,7 @@ def test_python_wrapper_python_runner_factory_failed(_):
     trace_mock.prepare.assert_called_once()
     trace_mock.send_traces.assert_not_called()
     trace_mock.set_runner.assert_not_called()
+    trace_mock.reset_mock()
 
 
 @mock.patch(


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_python_wrapper_python_runner_factory_failed` by resetting `trace_mock.call_count` to initial state 0 by calling method `reset_mock`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/wrappers/test_python_function.py::test_python_wrapper_python_runner_factory_failed`:

```
        with mock.patch(
                'epsagon.runners.python_function.PythonRunner',
                side_effect=TypeError()
        ):
            assert wrapped_function('a', 'b') == 'success'
    
>       trace_mock.prepare.assert_called_once()
...
>           raise AssertionError(msg)
E           AssertionError: Expected 'prepare' to have been called once. Called 2 times.
E           Calls: [call(), call()].
../../.local/lib/python3.8/site-packages/mock/mock.py:891: AssertionError
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
