### PR TITLE
fix(travis): allow PRs from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ install:
 script:
   - ./scripts/run_lint.sh
   - ./scripts/run_tests.sh
-  - npm install && export PATH=$(pwd)/node_modules/.bin:$PATH
-  - ./acceptance/run.sh $TRAVIS_BUILD_NUMBER $TRAVIS_PYTHON_VERSION
+  - 'if [ $AWS_ACCESS_KEY_ID ]; then ./scripts/run_acceptance_tests.sh; fi'
 
 jobs:
   include:

--- a/scripts/run_acceptance_tests.sh
+++ b/scripts/run_acceptance_tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+if [ -z $AWS_ACCESS_KEY_ID ] || [ -z $AWS_SECRET_ACCESS_KEY ]; then
+    echo "AWS credentials must be set in order to run acceptance tests"
+    exit 1
+else
+    npm install && export PATH=$(pwd)/node_modules/.bin:$PATH
+    ../acceptance/run.sh $TRAVIS_BUILD_NUMBER $TRAVIS_PYTHON_VERSION
+fi

--- a/scripts/run_acceptance_tests.sh
+++ b/scripts/run_acceptance_tests.sh
@@ -4,5 +4,5 @@ if [ -z $AWS_ACCESS_KEY_ID ] || [ -z $AWS_SECRET_ACCESS_KEY ]; then
     exit 1
 else
     npm install && export PATH=$(pwd)/node_modules/.bin:$PATH
-    ../acceptance/run.sh $TRAVIS_BUILD_NUMBER $TRAVIS_PYTHON_VERSION
+    ./acceptance/run.sh $TRAVIS_BUILD_NUMBER $TRAVIS_PYTHON_VERSION
 fi


### PR DESCRIPTION
Currently it is not possible to run travis builds on PRs originated from forks. This is due to the fact that travis doesn't use the configured build secrets for unauthorized users (as it might be a security risk).
In order to overcome it, acceptance tests will run as they always have for authorized users. For unauthorized users, acceptance tests will run only after merge to master. Issues with acceptance tests will have to be addressed before a new version is published.