### PR TITLE
fix(HTTPTransport): No retries will be made when trying to reach url and getting a timeout

### DIFF
--- a/epsagon/trace_transports.py
+++ b/epsagon/trace_transports.py
@@ -56,5 +56,6 @@ class HTTPTransport(object):
             'POST',
             self.dest,
             body=to_json(trace.to_dict()),
-            timeout=self.timeout
+            timeout=self.timeout,
+            retries=False
         )

--- a/scripts/run_acceptance_tests.sh
+++ b/scripts/run_acceptance_tests.sh
@@ -2,7 +2,7 @@
 if [ -z $AWS_ACCESS_KEY_ID ] || [ -z $AWS_SECRET_ACCESS_KEY ]; then
     echo "AWS credentials must be set in order to run acceptance tests"
     exit 1
-else
+elif [ $TRAVIS_PYTHON_VERSION != "2.7" ]; then
     npm install && export PATH=$(pwd)/node_modules/.bin:$PATH
     ./acceptance/run.sh $TRAVIS_BUILD_NUMBER $TRAVIS_PYTHON_VERSION
 fi

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -3,7 +3,7 @@
 ret=`python -c 'import sys; print(0 if sys.version_info < (3, 5, 3) else 1)'`
 excludes=''
 if [ $ret -eq 0 ]; then
-    pytest -vv --ignore-glob=*fastapi* --ignore-glob=*requests_event*
+    pytest -vv --ignore-glob=*fastapi* --ignore-glob=*requests_event* --ignore-glob=*transports*
 else
     pytest -vv
 fi

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -582,6 +582,7 @@ def test_send_traces_sanity(wrapped_post):
         'collector',
         body=json.dumps(trace.to_dict()),
         timeout=epsagon.constants.SEND_TIMEOUT,
+        retries=False,
     )
 
 
@@ -596,6 +597,7 @@ def test_send_traces_unicode(wrapped_post):
         'collector',
         body=json.dumps(trace.to_dict(), ensure_ascii=True),
         timeout=epsagon.constants.SEND_TIMEOUT,
+        retries=False,
     )
 
 
@@ -628,6 +630,7 @@ def test_send_big_trace(wrapped_post):
         'collector',
         body=json.dumps(trace.to_dict()),
         timeout=epsagon.constants.SEND_TIMEOUT,
+        retries=False,
     )
 
 
@@ -655,6 +658,7 @@ def test_strong_keys_not_trimmed(wrapped_post):
         'collector',
         body=json.dumps(trace.to_dict()),
         timeout=epsagon.constants.SEND_TIMEOUT,
+        retries=False,
     )
 
 
@@ -677,6 +681,7 @@ def test_send_invalid_return_value(wrapped_post):
         'collector',
         body=json.dumps(trace.to_dict()),
         timeout=epsagon.constants.SEND_TIMEOUT,
+        retries=False,
     )
 
 def _assert_key_not_exist(data, ignored_key):
@@ -870,6 +875,7 @@ def test_whitelist_full_flow(wrapped_post):
         'collector',
         body=json.dumps(trace.to_dict()),
         timeout=epsagon.constants.SEND_TIMEOUT,
+        retries=False,
     )
 
     os.environ.pop('EPSAGON_ALLOWED_KEYS')
@@ -895,6 +901,7 @@ def test_metadata_field_too_big(wrapped_post):
         'collector',
         body=json.dumps(trace.to_dict()),
         timeout=epsagon.constants.SEND_TIMEOUT,
+        retries=False,
     )
 
 
@@ -908,6 +915,7 @@ def test_send_traces_timeout(wrapped_post):
         'collector',
         body=json.dumps(trace.to_dict()),
         timeout=epsagon.constants.SEND_TIMEOUT,
+        retries=False,
     )
 
 
@@ -921,6 +929,7 @@ def test_send_traces_post_error(wrapped_post):
         'collector',
         body=json.dumps(trace.to_dict()),
         timeout=epsagon.constants.SEND_TIMEOUT,
+        retries=False,
     )
 
 
@@ -1360,6 +1369,7 @@ def test_event_with_datetime(wrapped_post):
         'collector',
         body=json.dumps(trace.to_dict(), cls=TraceEncoder),
         timeout=epsagon.constants.SEND_TIMEOUT,
+        retries=False,
     )
 
 @mock.patch('urllib3.PoolManager.request', side_effect=urllib3.exceptions.TimeoutError)
@@ -1378,6 +1388,7 @@ def test_event_with_non_unicode_binary(wrapped_post):
         'collector',
         body=json.dumps(trace.to_dict(), cls=TraceEncoder),
         timeout=epsagon.constants.SEND_TIMEOUT,
+        retries=False,
     )
 
 @mock.patch('urllib3.PoolManager.request')

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,0 +1,31 @@
+import time
+from pytest_httpserver import HTTPServer
+import pytest
+import urllib3
+from epsagon.trace_transports import HTTPTransport
+from epsagon.trace import (trace_factory)
+
+
+def test_sanity(httpserver: HTTPServer):
+    collector_url = '/collector'
+    httpserver.expect_request(collector_url).respond_with_data("success")
+    http_transport = HTTPTransport(httpserver.url_for(collector_url), 'token')
+    trace = trace_factory.get_or_create_trace()
+    http_transport.send(trace)
+
+
+def test_timeout():
+    start_time = time.time()
+    # non-routable IP address, will result in a timeout
+    http_transport = HTTPTransport('http://10.255.255.1', 'token')
+    trace = trace_factory.get_or_create_trace()
+
+    # This will make sure we get TimeoutError and not MaxRetryError
+    with pytest.raises(urllib3.exceptions.TimeoutError):
+        http_transport.send(trace)
+
+    duration = time.time() - start_time
+
+    # Making sure that an unreachable url will result in duration almost equal to the
+    # timeout duration set
+    assert http_transport.timeout < duration < http_transport.timeout + 0.3

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,16 +1,18 @@
 import time
 import pytest
+from pytest_httpserver import HTTPServer
 import urllib3
 from epsagon.trace_transports import HTTPTransport
 from epsagon.trace import (trace_factory)
 
 
-def test_sanity(httpserver):
-    collector_url = '/collector'
-    httpserver.expect_request(collector_url).respond_with_data("success")
-    http_transport = HTTPTransport(httpserver.url_for(collector_url), 'token')
-    trace = trace_factory.get_or_create_trace()
-    http_transport.send(trace)
+def test_sanity():
+    with HTTPServer() as httpserver:
+        collector_url = '/collector'
+        httpserver.expect_request(collector_url).respond_with_data("success")
+        http_transport = HTTPTransport(httpserver.url_for(collector_url), 'token')
+        trace = trace_factory.get_or_create_trace()
+        http_transport.send(trace)
 
 
 def test_timeout():

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,12 +1,11 @@
 import time
-from pytest_httpserver import HTTPServer
 import pytest
 import urllib3
 from epsagon.trace_transports import HTTPTransport
 from epsagon.trace import (trace_factory)
 
 
-def test_sanity(httpserver: HTTPServer):
+def test_sanity(httpserver):
     collector_url = '/collector'
     httpserver.expect_request(collector_url).respond_with_data("success")
     http_transport = HTTPTransport(httpserver.url_for(collector_url), 'token')

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -5,7 +5,7 @@ from epsagon.trace_transports import HTTPTransport
 from epsagon.trace import (trace_factory)
 
 
-def test_sanity(httpserver):
+def test_httptransport_sanity(httpserver):
     collector_url = '/collector'
     httpserver.expect_request(collector_url).respond_with_data("success")
     http_transport = HTTPTransport(httpserver.url_for(collector_url), 'token')
@@ -13,7 +13,7 @@ def test_sanity(httpserver):
     http_transport.send(trace)
 
 
-def test_timeout():
+def test_httptransport_timeout():
     start_time = time.time()
     # non-routable IP address, will result in a timeout
     http_transport = HTTPTransport('http://10.255.255.1', 'token')

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,18 +1,16 @@
 import time
 import pytest
-from pytest_httpserver import HTTPServer
 import urllib3
 from epsagon.trace_transports import HTTPTransport
 from epsagon.trace import (trace_factory)
 
 
-def test_sanity():
-    with HTTPServer() as httpserver:
-        collector_url = '/collector'
-        httpserver.expect_request(collector_url).respond_with_data("success")
-        http_transport = HTTPTransport(httpserver.url_for(collector_url), 'token')
-        trace = trace_factory.get_or_create_trace()
-        http_transport.send(trace)
+def test_sanity(httpserver):
+    collector_url = '/collector'
+    httpserver.expect_request(collector_url).respond_with_data("success")
+    http_transport = HTTPTransport(httpserver.url_for(collector_url), 'token')
+    trace = trace_factory.get_or_create_trace()
+    http_transport.send(trace)
 
 
 def test_timeout():


### PR DESCRIPTION
When HTTPTransport was getting a timeout while trying to send out traces, it was retrying to send those traces (because of urlib3 configuration), this resulted in application delays when the url is unreachable.

Now the urlib3 in HTTPTransport is configured to not have any retries on failed attempts to reach the url.