### PR TITLE
Replace deprecated threading.currentThread with current_thread

### DIFF
--- a/epsagon/trace.py
+++ b/epsagon/trace.py
@@ -62,7 +62,7 @@ def get_thread_id():
     Return current thread id
     :return: thread id
     """
-    return threading.currentThread().ident
+    return threading.current_thread().ident
 
 
 def create_transport(collector_url, token):


### PR DESCRIPTION
`threading.currentThread` was deprecated in Python 3.10 (October 2021) and will be removed in Python 3.12 (October 2023).

Replace with `threading.current_thread`, added in Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174

